### PR TITLE
Refactoring PlayState to make ScaleDrillState easier

### DIFF
--- a/data/menu_config.py
+++ b/data/menu_config.py
@@ -26,13 +26,13 @@ MAIN_MENU = {
                                     "text": "Random",
                                     "type": "scale_drill",
                                     "payload": {
-                                        "name": "C Major",
+                                        "name": "C Major (Random)",
                                         "notes": ["C_4", "D_4", "E_4", "F_4", "G_4", "A_4", "B_4", "C_5"]
                                     }
-                                }
+                                },
+                                {"text": "< Back", "type": "back"}
                             ]
                         },
-
                         {"text": "< Back", "type": "back"}
                     ]
                 },

--- a/data/notes.py
+++ b/data/notes.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from hardware.buttons import Buttons
 
 class Accidental:
@@ -156,7 +158,7 @@ class Notes:
             MASK_TO_NOTE[mask] = note
 
     @staticmethod
-    def get_note_by_name(name):
+    def get_note_by_name(name) -> Note | None:
         """Returns the Note instance corresponding to the given name string."""
         return getattr(Notes, name, None)
 

--- a/data/notes.py
+++ b/data/notes.py
@@ -155,6 +155,11 @@ class Notes:
         for mask in note.fingerings:
             MASK_TO_NOTE[mask] = note
 
+    @staticmethod
+    def get_note_by_name(name):
+        """Returns the Note instance corresponding to the given name string."""
+        return getattr(Notes, name, None)
+
 
 def note_from_mask(mask):
     note = Notes.MASK_TO_NOTE.get(mask, None)

--- a/states/play_state.py
+++ b/states/play_state.py
@@ -18,7 +18,7 @@ class PlayState:
     HIGH_C_LEDGER_LINE_Y = 54
     E_LEDGER_LINE_Y = 32
 
-    def __init__(self, hardware, config: Config):
+    def __init__(self, hardware, config: Config, title="Free Play"):
         self.hw = hardware
         self.is_running = True
         self.current_note_playing = None
@@ -36,9 +36,9 @@ class PlayState:
         # Drill Name along the top
         self.title_label = label.Label(
             terminalio.FONT,
-            text="Free Play",
+            text=title,
             color=config.color_data.fg_color,
-            scale=2,
+            scale=1,
             x=10,
             y=15
         )

--- a/states/play_state.py
+++ b/states/play_state.py
@@ -4,9 +4,10 @@ import displayio
 import terminalio
 import adafruit_imageload
 from adafruit_display_text import label
+from displayio import TileGrid
 
-from data.config import ColorConfig, Config
-from data.notes import Accidental, Notes
+from data.config import Config
+from data.notes import Accidental, Notes, Note
 from hardware.buttons import Buttons
 from hardware.saxophone import SaxHardware
 
@@ -17,6 +18,9 @@ class PlayState:
     A_LEDGER_LINE_Y = 76
     HIGH_C_LEDGER_LINE_Y = 54
     E_LEDGER_LINE_Y = 32
+
+    STAFF_Y = (240 // 2) - (69 // 2) + 11  # Center vertically, move down to allow more room for notes
+    STAFF_X_START = 32  # Start a bit in from the left
 
     def __init__(self, hardware, config: Config, title="Free Play"):
         self.hw = hardware
@@ -44,7 +48,7 @@ class PlayState:
         )
         self.ui_group.append(self.title_label)
         
-        # Load Staff Lines (69x69)
+        # Load Staff Lines
         staff_bitmap, staff_palette = adafruit_imageload.load(
             "data/img/staff_lines_white.png", 
             bitmap=displayio.Bitmap, 
@@ -55,18 +59,17 @@ class PlayState:
         staff_palette[0] = config.color_data.fg_color
         
         # Two copies of the staff side-by-side, centered vertically
-        staff_y = (240 // 2) - (69 // 2) + 11 # Center vertically, move down to allow more room for notes
-        staff_x_start = 32 # Start a bit in from the left
-        
-        self.staff_1 = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=staff_x_start, y=staff_y)
-        self.staff_2 = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=staff_x_start + 60, y=staff_y)
-        self.c_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=staff_x_start + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
-        self.a_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=staff_x_start + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
-        self.high_c_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=staff_x_start + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
-        self.e_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=staff_x_start + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
-
+        self.staff_1 = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=PlayState.STAFF_X_START, y=PlayState.STAFF_Y)
+        self.staff_2 = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=PlayState.STAFF_X_START + 60, y=PlayState.STAFF_Y)
         self.ui_group.append(self.staff_1)
         self.ui_group.append(self.staff_2)
+
+        # use staff for ledger lines
+        self.c_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=PlayState.STAFF_X_START + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
+        self.a_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=PlayState.STAFF_X_START + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
+        self.high_c_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=PlayState.STAFF_X_START + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
+        self.e_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=staff_palette, x=PlayState.STAFF_X_START + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
+
         self.ui_group.append(self.c_ledger_line)
         self.ui_group.append(self.a_ledger_line)
         self.ui_group.append(self.high_c_ledger_line)
@@ -83,8 +86,8 @@ class PlayState:
         clef_palette[0] = config.color_data.fg_color
         
         # Place treble clef on the far left of the staff
-        clef_y = staff_y - 2 # Minor adjustment to align with staff visually
-        self.treble_clef = displayio.TileGrid(clef_bitmap, pixel_shader=clef_palette, x=staff_x_start - 20, y=clef_y)
+        clef_y = PlayState.STAFF_Y - 2 # Minor adjustment to align with staff visually
+        self.treble_clef = displayio.TileGrid(clef_bitmap, pixel_shader=clef_palette, x=PlayState.STAFF_X_START - 20, y=clef_y)
         self.ui_group.append(self.treble_clef)
 
         # Load Half Note
@@ -99,7 +102,7 @@ class PlayState:
         note_palette[0] = config.color_data.fg_color
         
         # Place note on the staff (starting position will be updated in run)
-        self.note_sprite = displayio.TileGrid(note_bitmap, pixel_shader=note_palette, x=staff_x_start + 60, y=PlayState.OFF_SCREEN_Y)
+        self.note_sprite = displayio.TileGrid(note_bitmap, pixel_shader=note_palette, x=PlayState.STAFF_X_START + 60, y=PlayState.OFF_SCREEN_Y)
         self.ui_group.append(self.note_sprite)
 
         #Load sharp
@@ -110,9 +113,10 @@ class PlayState:
         )
         sharp_palette.make_transparent(1)
         sharp_palette[0] = config.color_data.fg_color
-        self.sharp_sprite = displayio.TileGrid(sharp_bitmap, pixel_shader=sharp_palette, x=staff_x_start + 40, y=PlayState.OFF_SCREEN_Y)
+        self.sharp_sprite = displayio.TileGrid(sharp_bitmap, pixel_shader=sharp_palette, x=PlayState.STAFF_X_START + 40, y=PlayState.OFF_SCREEN_Y)
         self.ui_group.append(self.sharp_sprite)
 
+        #Load flat
         flat_bitmap, flat_palette = adafruit_imageload.load(
             "data/img/flat_white.png",
             bitmap=displayio.Bitmap,
@@ -120,7 +124,7 @@ class PlayState:
         )
         flat_palette.make_transparent(1)
         flat_palette[0] = config.color_data.fg_color
-        self.flat_sprite = displayio.TileGrid(flat_bitmap, pixel_shader=flat_palette, x=staff_x_start + 40, y=PlayState.OFF_SCREEN_Y)
+        self.flat_sprite = displayio.TileGrid(flat_bitmap, pixel_shader=flat_palette, x=PlayState.STAFF_X_START + 40, y=PlayState.OFF_SCREEN_Y)
         self.ui_group.append(self.flat_sprite)
 
         # load chart
@@ -191,39 +195,45 @@ class PlayState:
 
             # 2. Handle Note Logic
             target_note = self.hw.get_current_note()
-            breathing = self.hw.breath_sensor.breath_sensor_triggered
-
-            if target_note is None or not breathing:
-                self.hw.stop_note()
-                await self.hide_notes()
-                self.current_note_playing = None
-                continue
-
-            # 3. Apply changes if the note changed
-            if target_note != self.current_note_playing:
-                self.hw.stop_note()
-                await self.hide_notes()
-
-                if target_note is not None:
-                    self.hw.play_note(target_note.midi_number)
-                    self.note_sprite.y = target_note.staff_y_coord
-                    if target_note.accidental is Accidental.SHARP:
-                        self.sharp_sprite.y = self.note_sprite.y + 36
-                    if target_note.accidental is Accidental.FLAT:
-                        self.flat_sprite.y = self.note_sprite.y + 24
-                    if target_note in Notes.C_LINE:
-                        self.c_ledger_line.y = PlayState.C_LEDGER_LINE_Y
-                    if target_note in Notes.A_LINE:
-                        self.a_ledger_line.y = PlayState.A_LEDGER_LINE_Y
-                    if target_note in Notes.HIGH_C_LINE:
-                        self.high_c_ledger_line.y = PlayState.HIGH_C_LEDGER_LINE_Y
-                    if target_note in Notes.E_LINE:
-                        self.e_ledger_line.y = PlayState.E_LEDGER_LINE_Y
-
-                self.current_note_playing = target_note
-
-            self.hw.display.refresh()
+            await self.process_playing_note(target_note)
             await asyncio.sleep(0.001)
 
         # STOP AUDIO: Release notes before exiting the loop
         self.hw.stop_note()
+
+    async def process_playing_note(self, note):
+        breathing = self.hw.breath_sensor.breath_sensor_triggered
+        if note is None or not breathing:
+            self.hw.stop_note()
+            await self.hide_notes()
+            self.current_note_playing = None
+            return
+
+        # 3. Apply changes if the note changed
+        if note != self.current_note_playing:
+            self.hw.stop_note()
+            await self.hide_notes()
+
+            if note is not None:
+                self.hw.play_note(note.midi_number)
+                self.note_sprite.y = note.staff_y_coord
+                self.decorate_note(note, self.note_sprite, self.sharp_sprite, self.flat_sprite, self.c_ledger_line, self.a_ledger_line, self.high_c_ledger_line, self.e_ledger_line)
+
+            self.current_note_playing = note
+        self.hw.display.refresh()
+
+    @staticmethod
+    def decorate_note(note: Note, note_sprite: TileGrid, sharp_sprite: TileGrid, flat_sprite: TileGrid, c_ledger_line: TileGrid, a_ledger_line: TileGrid, high_c_ledger_line: TileGrid, e_ledger_line: TileGrid):
+        if note is not None:
+            if note.accidental is Accidental.SHARP and sharp_sprite.y == PlayState.OFF_SCREEN_Y:
+                sharp_sprite.y = note_sprite.y + 36
+            if note.accidental is Accidental.FLAT and flat_sprite.y == PlayState.OFF_SCREEN_Y:
+                flat_sprite.y = note_sprite.y + 24
+            if note in Notes.C_LINE and c_ledger_line.y == PlayState.OFF_SCREEN_Y:
+                c_ledger_line.y = PlayState.C_LEDGER_LINE_Y
+            if note in Notes.A_LINE and a_ledger_line.y == PlayState.OFF_SCREEN_Y:
+                a_ledger_line.y = PlayState.A_LEDGER_LINE_Y
+            if note in Notes.HIGH_C_LINE and high_c_ledger_line.y == PlayState.OFF_SCREEN_Y:
+                high_c_ledger_line.y = PlayState.HIGH_C_LEDGER_LINE_Y
+            if note in Notes.E_LINE and e_ledger_line.y == PlayState.OFF_SCREEN_Y:
+                e_ledger_line.y = PlayState.E_LEDGER_LINE_Y

--- a/states/scale_drill_state.py
+++ b/states/scale_drill_state.py
@@ -1,5 +1,9 @@
 import asyncio
 
+import adafruit_imageload
+import displayio
+
+from data.notes import Notes, Accidental
 from hardware.buttons import Buttons
 from states.play_state import PlayState
 
@@ -8,7 +12,57 @@ class ScaleDrillState(PlayState):
     def __init__(self, hardware, payload, config):
         self.drill_name = payload.get("name", "Unknown Drill")
         super().__init__(hardware, config, title=self.drill_name)
-        self.notes = payload.get("notes", [])
+
+        note_names = payload.get("notes", [])
+        self.notes = [Notes.get_note_by_name(name) for name in note_names if Notes.get_note_by_name(name) is not None]
+
+        # set up drill note display
+        drill_note_bitmap, drill_note_palette = adafruit_imageload.load(
+            "data/img/half_note_white.png",
+            bitmap=displayio.Bitmap,
+            palette=displayio.Palette
+        )
+        drill_note_palette.make_transparent(1)
+        drill_note_palette[0] = 0x00AA00
+        self.drill_note_sprite = displayio.TileGrid(drill_note_bitmap, pixel_shader=drill_note_palette, x=PlayState.STAFF_X_START + 60,
+                                              y=PlayState.OFF_SCREEN_Y)
+        self.ui_group.append(self.drill_note_sprite)
+
+        # Load Staff Lines
+        staff_bitmap, staff_palette = adafruit_imageload.load(
+            "data/img/staff_lines_white.png",
+            bitmap=displayio.Bitmap,
+            palette=displayio.Palette
+        )
+
+        # use staff for ledger lines
+        self.drill_c_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=drill_note_palette, x=PlayState.STAFF_X_START + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
+        self.drill_a_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=drill_note_palette, x=PlayState.STAFF_X_START + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
+        self.drill_high_c_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=drill_note_palette, x=PlayState.STAFF_X_START + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
+        self.drill_e_ledger_line = displayio.TileGrid(staff_bitmap, pixel_shader=drill_note_palette, x=PlayState.STAFF_X_START + 61, y=PlayState.OFF_SCREEN_Y, tile_width=32, tile_height=16)
+
+        self.ui_group.append(self.drill_c_ledger_line)
+        self.ui_group.append(self.drill_a_ledger_line)
+        self.ui_group.append(self.drill_high_c_ledger_line)
+        self.ui_group.append(self.drill_e_ledger_line)
+
+        #Load sharp
+        sharp_bitmap, sharp_palette = adafruit_imageload.load(
+            "data/img/sharp_white.png",
+            bitmap=displayio.Bitmap,
+            palette=displayio.Palette
+        )
+        self.drill_sharp_sprite = displayio.TileGrid(sharp_bitmap, pixel_shader=drill_note_palette, x=PlayState.STAFF_X_START + 40, y=PlayState.OFF_SCREEN_Y)
+        self.ui_group.append(self.drill_sharp_sprite)
+
+        #Load flat
+        flat_bitmap, flat_palette = adafruit_imageload.load(
+            "data/img/flat_white.png",
+            bitmap=displayio.Bitmap,
+            palette=displayio.Palette
+        )
+        self.drill_flat_sprite = displayio.TileGrid(flat_bitmap, pixel_shader=drill_note_palette, x=PlayState.STAFF_X_START + 40, y=PlayState.OFF_SCREEN_Y)
+        self.ui_group.append(self.drill_flat_sprite)
 
     async def run(self):
         while self.is_running:
@@ -19,4 +73,16 @@ class ScaleDrillState(PlayState):
                 self.is_running = False
                 break
 
+            # show current drill note
+            self.draw_drill_note(self.notes[0])
+
+            # show playing note
+            target_note = self.hw.get_current_note()
+            await self.process_playing_note(target_note)
+
+            # yield control for other code to run
             await asyncio.sleep(0.001)
+
+    def draw_drill_note(self, note):
+        self.drill_note_sprite.y = note.staff_y_coord
+        self.decorate_note(note, self.drill_note_sprite, self.drill_sharp_sprite, self.drill_flat_sprite, self.drill_c_ledger_line, self.drill_a_ledger_line, self.drill_high_c_ledger_line, self.drill_e_ledger_line)

--- a/states/scale_drill_state.py
+++ b/states/scale_drill_state.py
@@ -1,15 +1,22 @@
 import asyncio
-import displayio
-import terminalio
-import adafruit_imageload
-from adafruit_display_text import label
 
 from hardware.buttons import Buttons
 from states.play_state import PlayState
 
 
 class ScaleDrillState(PlayState):
-    def __init__(self, hardware, payload, color_data):
-        super().__init__(hardware, color_data)
+    def __init__(self, hardware, payload, config):
         self.drill_name = payload.get("name", "Unknown Drill")
+        super().__init__(hardware, config, title=self.drill_name)
         self.notes = payload.get("notes", [])
+
+    async def run(self):
+        while self.is_running:
+            self.hw.update_button_states()
+
+            if Buttons.L_SELECT.just_pressed:
+                # exit if select button pressed
+                self.is_running = False
+                break
+
+            await asyncio.sleep(0.001)


### PR DESCRIPTION
1. Break out PlayState's display of sharp, flat, ledger lines ("decorating the note") into a separate method that allows one to pass in the TileGrids to use. This allows us to call this method to display and decorate other notes.
2. Break out the PlayState code that detects and plays the current playing note into a method, to simplify and allow customization around this step of the code.
3. Add a helper method to Notes that can take a note by name and return the Note class. This allows us to translate the list of notes in the drill config into Notes that have all of their properties like y position, midi number, etc.
4. Minor fixes like adding a 'back' to the Scale menu.
5. Add sharp, flat, ledger line TileGrids for the drill target note in DrillScaleState