### PR TITLE
feature: ability to play mp3s and play along

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DEST = /Volumes/CIRCUITPY/
 # Default target
 deploy:
 	@echo "Deploying to CircuitPython..."
-	rsync -rtuv --exclude='.DS_Store' hardware data states $(DEST)
+	rsync -rtuv --exclude='.DS_Store' hardware data states songs $(DEST)
 	rsync -rtuv code.py $(DEST)
 	@echo "Deployment complete!"
 

--- a/data/menu_config.py
+++ b/data/menu_config.py
@@ -41,11 +41,7 @@ MAIN_MENU = {
         },
         {
             "text": "SONGS",
-            "type": "menu",
-            "items": [
-                {"text": "COMING SOON", "type": "info"},
-                {"text": "< Back", "type": "back"}
-            ]
+            "type": "song"
         },
         {
             "text": "FREE PLAY",

--- a/hardware/saxophone.py
+++ b/hardware/saxophone.py
@@ -50,7 +50,7 @@ class SaxHardware:
 
         # 3. Create the Mixer and play it on the audio bus
         self.mixer = audiomixer.Mixer(
-            voice_count=1,
+            voice_count=2,
             sample_rate=22050,
             channel_count=1,
             bits_per_sample=16,

--- a/songs/README.md
+++ b/songs/README.md
@@ -1,0 +1,1 @@
+Place MP3 formatted songs in this folder

--- a/states/menu_state.py
+++ b/states/menu_state.py
@@ -1,12 +1,9 @@
 import asyncio
 import gc
 
-import displayio
-import terminalio
-from adafruit_display_text import label
-
 from data.config import ColorConfig, Config
 from hardware.buttons import Buttons
+from states.state_utils import SelectableList
 
 
 class MenuState:
@@ -14,95 +11,44 @@ class MenuState:
         self.hw = hardware
         self.current_menu = menu_data
         self.menu_stack = []
-        self.selected_index = 0
-        self.scroll_offset = 0
-        self.max_visible_items = 4
         self.config = Config()
 
-        self.ui_group = displayio.Group()
-        self.hw.display.root_group = self.ui_group
-        self.labels = []
-
-        self.title_label = label.Label(terminalio.FONT, text="", color=0x00AAFF, scale=3, x=10, y=20)
-        self.ui_group.append(self.title_label)
-
-        self.render_menu()
-
-    def render_menu(self):
-        while len(self.ui_group) > 1:
-            self.ui_group.pop()
-
-        self.labels = []
+        # The selectable list handles drawing items and selection logic
         header_text = self.current_menu.get("title", self.current_menu.get("text", "MENU"))
-        self.title_label.text = header_text
+        self.selectable_list = SelectableList(title=header_text)
+        
+        # We hook the SelectableList's UI group to the display
+        self.hw.display.root_group = self.selectable_list.ui_group
 
-        start_index = self.scroll_offset
-        end_index = min(len(self.current_menu["items"]), self.scroll_offset + self.max_visible_items)
-
-        for i in range(start_index, end_index):
-            item = self.current_menu["items"][i]
-            is_selected = (i == self.selected_index)
-            color = 0x00FF00 if is_selected else 0xFFFFFF
-            prefix = "> " if is_selected else "  "
-
-            y_pos = 80 + ((i - self.scroll_offset) * 35)
-            lbl = label.Label(terminalio.FONT, text=f"{prefix}{item['text']}", color=color, scale=2, x=20,
-                              y=y_pos)
-            self.labels.append(lbl)
-            self.ui_group.append(lbl)
-
-        # Scrolling indicators (arrows)
-        if self.scroll_offset > 0:
-            up_arrow = label.Label(terminalio.FONT, text="^", color=0xAAAAAA, scale=2, x=40, y=60)
-            self.ui_group.append(up_arrow)
-
-        # Show down arrow if there are items remaining in the list beyond the current view
-        has_more_below = len(self.current_menu["items"]) > end_index
-
-        if has_more_below:
-            last_visible_idx = end_index - 1
-            # Clamp Y to 220 to ensure it stays on screen
-            down_y = min(80 + ((last_visible_idx - self.scroll_offset) * 35) + 35, 220)
-            down_arrow = label.Label(terminalio.FONT, text="v", color=0xAAAAAA, scale=2, x=40, y=down_y)
-            self.ui_group.append(down_arrow)
-
-    def update_selection_ui(self):
-        if self.selected_index < self.scroll_offset:
-            self.scroll_offset = self.selected_index
-        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
-            self.scroll_offset = self.selected_index - self.max_visible_items + 1
-
-        self.render_menu()
+        self.selectable_list.set_items(self.current_menu["items"], title=header_text)
 
     async def run(self):
         while True:
             self.hw.update_button_states()
 
             if Buttons.R_1.just_pressed:
-                self.selected_index = (self.selected_index - 1) % len(self.current_menu["items"])
-                self.update_selection_ui()
+                self.selectable_list.move_up()
             elif Buttons.R_2.just_pressed:
-                self.selected_index = (self.selected_index + 1) % len(self.current_menu["items"])
-                self.update_selection_ui()
+                self.selectable_list.move_down()
             elif Buttons.L_SELECT.just_pressed:
-                selected_item = self.current_menu["items"][self.selected_index]
+                selected_item = self.selectable_list.get_selected_item()
+                if not selected_item:
+                    continue
+                    
                 item_type = selected_item.get("type")
-
 
                 if item_type == "back":
                     if self.menu_stack:
                         self.current_menu = self.menu_stack.pop()
-                        self.selected_index = 0
-                        self.scroll_offset = 0
-                        self.render_menu()
+                        header_text = self.current_menu.get("title", self.current_menu.get("text", "MENU"))
+                        self.selectable_list.set_items(self.current_menu["items"], title=header_text)
 
                 elif item_type == "menu":
                     if "items" in selected_item and len(selected_item["items"]) > 0:
                         self.menu_stack.append(self.current_menu)
                         self.current_menu = selected_item
-                        self.selected_index = 0
-                        self.scroll_offset = 0
-                        self.render_menu()
+                        header_text = self.current_menu.get("title", self.current_menu.get("text", "MENU"))
+                        self.selectable_list.set_items(self.current_menu["items"], title=header_text)
                     else:
                         print(f"Warning: '{selected_item.get('text')}' has no items!")
 
@@ -122,14 +68,22 @@ class MenuState:
                     await next_state.run()
                     del next_state
                     gc.collect()
-                    self.hw.display.root_group = self.ui_group
+                    self.hw.display.root_group = self.selectable_list.ui_group
                 elif item_type == "play":
                     from states.play_state import PlayState
                     next_state = PlayState(self.hw, self.config)
                     await next_state.run()
                     del next_state
                     gc.collect()
-                    self.hw.display.root_group = self.ui_group
+                    self.hw.display.root_group = self.selectable_list.ui_group
+                elif item_type == "song":
+                    payload = selected_item.get("payload", {})
+                    from states.song_state import SongState
+                    next_state = SongState(self.hw, payload, self.config)
+                    await next_state.run()
+                    del next_state
+                    gc.collect()
+                    self.hw.display.root_group = self.selectable_list.ui_group
                 else:
                     print(f"Error: Unhandled menu type '{item_type}'")
 

--- a/states/play_state.py
+++ b/states/play_state.py
@@ -28,7 +28,6 @@ class PlayState:
         self.current_note_playing = None
 
         self.ui_group = displayio.Group()
-        self.hw.display.root_group = self.ui_group
 
         # Background
         color_bitmap = displayio.Bitmap(320, 240, 1)
@@ -180,7 +179,12 @@ class PlayState:
 
 
     async def run(self):
-        self.ui_group.append(self.chart_sprite)
+        if self.hw.display.root_group != self.ui_group:
+            self.hw.display.root_group = self.ui_group
+
+        if self.chart_sprite not in self.ui_group:
+            self.ui_group.append(self.chart_sprite)
+
         self.current_note_playing = None
         self.hw.stop_note()
         await self.hide_notes()

--- a/states/scale_drill_state.py
+++ b/states/scale_drill_state.py
@@ -66,6 +66,9 @@ class ScaleDrillState(PlayState):
 
     async def run(self):
         while self.is_running:
+            if self.hw.display.root_group != self.ui_group:
+                self.hw.display.root_group = self.ui_group
+
             self.hw.update_button_states()
 
             if Buttons.L_SELECT.just_pressed:

--- a/states/song_state.py
+++ b/states/song_state.py
@@ -1,0 +1,95 @@
+import asyncio
+import audiomp3
+import os
+
+from states.play_state import PlayState
+from states.state_utils import SelectableList
+from hardware.buttons import Buttons
+
+
+class SongState(PlayState):
+    SONG_DIR = "songs"
+    AUDIO_BUFFER = bytearray(16384)
+
+    def __init__(self, hardware, payload, config):
+        # Initialize PlayState stuff, but don't show its UI yet
+        super().__init__(hardware, config, title="Song Mode")
+        self.payload = payload
+        
+        # Setup the selectable list for songs
+        self.selectable_list = SelectableList(title="Select Song")
+        
+        # Load available songs from a directory
+        self.songs = self._get_song_list()
+        self.menu_items = self.songs + [{"text": "< Back", "type": "back"}]
+        self.selectable_list.set_items(self.menu_items, title="Select Song")
+
+        # Initially, show the selectable list UI instead of PlayState UI
+        self.hw.display.root_group = self.selectable_list.ui_group
+
+    @staticmethod
+    def _get_song_list():
+        try:
+            files = os.listdir(SongState.SONG_DIR)
+            # Create a dictionary entry for each song so it renders nicely
+            songs = [{"text": f, "type": "song_item", "file": SongState.SONG_DIR + "/" + f} for f in files if f.endswith(".mp3") and not f.startswith(".")]
+            if not songs:
+                return [{"text": "No songs found", "type": "info"}]
+            return songs
+        except Exception as e:
+            print(f"Error reading songs: {e}")
+            return [{"text": "No songs found", "type": "info"}]
+
+    async def _handle_menu(self):
+        """Handles the song selection menu loop. Returns the selected song or None if back was pressed."""
+        while True:
+            self.hw.update_button_states()
+            
+            if Buttons.R_1.just_pressed:
+                self.selectable_list.move_up()
+            elif Buttons.R_2.just_pressed:
+                self.selectable_list.move_down()
+            elif Buttons.L_SELECT.just_pressed:
+                selected_item = self.selectable_list.get_selected_item()
+                if not selected_item:
+                    continue
+                    
+                item_type = selected_item.get("type")
+                
+                if item_type == "back":
+                    return None
+                elif item_type == "song_item":
+                    return selected_item
+                elif item_type == "info":
+                    pass
+                    
+            await asyncio.sleep(0.01)
+
+    async def run(self):
+        while True:
+            # Enter the menu for song listing
+            if self.hw.display.root_group != self.selectable_list.ui_group:
+                self.hw.display.root_group = self.selectable_list.ui_group
+            
+            selected_song = await self._handle_menu()
+            
+            if not selected_song:
+                # User pressed back, exit SongState entirely
+                return
+                
+            print(f"Selected song: {selected_song['text']}")
+            
+            # The file must remain open while playing. We use a 'with' block 
+            # to guarantee the file handle is cleaned up when we exit this song.
+            with open(selected_song['file'], "rb") as mp3_file:
+                decoder = audiomp3.MP3Decoder(mp3_file, SongState.AUDIO_BUFFER)
+                self.hw.mixer.voice[1].level = 0.3
+                self.hw.mixer.voice[1].play(decoder)
+                
+                # Reset PlayState's running flag in case we played a song previously
+                self.is_running = True
+                
+                # Hand over control to PlayState's run loop.
+                await super().run()
+
+                self.hw.mixer.voice[1].stop()

--- a/states/state_utils.py
+++ b/states/state_utils.py
@@ -1,0 +1,83 @@
+import displayio
+import terminalio
+from adafruit_display_text import label
+
+class SelectableList:
+    def __init__(self, title=""):
+        self.items = []
+        self.selected_index = 0
+        self.scroll_offset = 0
+        self.max_visible_items = 4
+        self.title = title
+        
+        self.ui_group = displayio.Group()
+        self.labels = []
+        
+        self.title_label = label.Label(terminalio.FONT, text=self.title, color=0x00AAFF, scale=3, x=10, y=20)
+        self.ui_group.append(self.title_label)
+        
+    def set_items(self, items, title=None):
+        self.items = items
+        if title is not None:
+            self.title = title
+            self.title_label.text = self.title
+        self.selected_index = 0
+        self.scroll_offset = 0
+        self.render()
+
+    def render(self):
+        while len(self.ui_group) > 1:
+            self.ui_group.pop()
+
+        self.labels = []
+        
+        start_index = self.scroll_offset
+        end_index = min(len(self.items), self.scroll_offset + self.max_visible_items)
+
+        for i in range(start_index, end_index):
+            item = self.items[i]
+            # Handle if items are dicts or objects
+            text = item.get("text", str(item)) if isinstance(item, dict) else str(item)
+            is_selected = (i == self.selected_index)
+            color = 0x00FF00 if is_selected else 0xFFFFFF
+            prefix = "> " if is_selected else "  "
+
+            y_pos = 80 + ((i - self.scroll_offset) * 35)
+            lbl = label.Label(terminalio.FONT, text=f"{prefix}{text}", color=color, scale=2, x=20,
+                              y=y_pos)
+            self.labels.append(lbl)
+            self.ui_group.append(lbl)
+
+        # Scrolling indicators (arrows)
+        if self.scroll_offset > 0:
+            up_arrow = label.Label(terminalio.FONT, text="^", color=0xAAAAAA, scale=2, x=40, y=60)
+            self.ui_group.append(up_arrow)
+
+        has_more_below = len(self.items) > end_index
+
+        if has_more_below:
+            last_visible_idx = end_index - 1
+            down_y = min(80 + ((last_visible_idx - self.scroll_offset) * 35) + 35, 220)
+            down_arrow = label.Label(terminalio.FONT, text="v", color=0xAAAAAA, scale=2, x=40, y=down_y)
+            self.ui_group.append(down_arrow)
+
+    def move_up(self):
+        if not self.items: return
+        self.selected_index = (self.selected_index - 1) % len(self.items)
+        self.update_selection_ui()
+
+    def move_down(self):
+        if not self.items: return
+        self.selected_index = (self.selected_index + 1) % len(self.items)
+        self.update_selection_ui()
+        
+    def get_selected_item(self):
+        if not self.items: return None
+        return self.items[self.selected_index]
+
+    def update_selection_ui(self):
+        if self.selected_index < self.scroll_offset:
+            self.scroll_offset = self.selected_index
+        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
+            self.scroll_offset = self.selected_index - self.max_visible_items + 1
+        self.render()


### PR DESCRIPTION
-  Move the MenuState logic that draws lists of items into a utils class "SelectableList"
-  add empty songs directory and README to deploy
-  Add another voice channel to the mixer in order to play songs in parallel with sax notes
-  Implement SongState as a child of PlayState
    - Generate a SelectableList based on reading contents of songs directory, filtering for mp3s
    -  When a song is chosen, play this song and then start the usual PlayState
    -  When song is exited, show the list of songs again