### PR TITLE
Add calibration function to learn button/pin mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Variables
-DEST = /Volumes/CIRCUITPY/
+DEST = /Volumes/CIRCUITPY
 
 
 # Default target
@@ -19,3 +19,6 @@ deps:
 setup-device: deps
 	@echo "Installing libraries to device"
 	circup install asyncio adafruit_display_text adafruit_ili9341 adafruit_mcp230xx adafruit_imageload adafruit_bmp3xx
+
+calibrate:
+	touch $(DEST)/CALIBRATE

--- a/code.py
+++ b/code.py
@@ -1,6 +1,9 @@
 # code.py
 import asyncio
+import gc
+
 from hardware.saxophone import SaxHardware
+from states.calibration_state import CalibrationState, calibrate_requested
 from states.menu_state import MenuState
 from data.menu_config import MAIN_MENU
 from data.config import Config
@@ -11,6 +14,12 @@ async def main():
 
     hw = SaxHardware()
     await hw.start_hardware()
+
+    if calibrate_requested():
+        calibration = CalibrationState(hw, config)
+        await calibration.run()
+        del calibration
+        gc.collect()
 
     initial_state = MenuState(hw, MAIN_MENU, config)
 

--- a/code.py
+++ b/code.py
@@ -12,7 +12,7 @@ from data.config import Config
 async def main():
     config = Config.load_config()
 
-    hw = SaxHardware()
+    hw = SaxHardware(config)
     await hw.start_hardware()
 
     if calibrate_requested():

--- a/data/menu_config.py
+++ b/data/menu_config.py
@@ -183,128 +183,132 @@ MAIN_MENU = {
                         {"text": "< Back", "type": "back"}
                     ]
                 },
-                {"text": "< Back", "type": "back"}
-            ]
-        },
-        {
-            "text": "SONGS",
-            "type": "menu",
-            "items": [
                 {
-                    "text": "Twinkle Twinkle",
-                    "type": "scale_drill",
-                    "payload": {
-                        "name": "Twinkle Twinkle",
-                        "key_signature": "C_MAJOR",
-                        "notes": [
-                            "C_4", "C_4", "G_4", "G_4", "A_4", "A_4", "G_4",
-                            "F_4", "F_4", "E_4", "E_4", "D_4", "D_4", "C_4",
-                            "G_4", "G_4", "F_4", "F_4", "E_4", "E_4", "D_4",
-                            "G_4", "G_4", "F_4", "F_4", "E_4", "E_4", "D_4",
-                            "C_4", "C_4", "G_4", "G_4", "A_4", "A_4", "G_4",
-                            "F_4", "F_4", "E_4", "E_4", "D_4", "D_4", "C_4"
-                        ],
-                        "mode": "none"
-                    }
-                },
-                {
-                    "text": "Happy Birthday",
-                    "type": "scale_drill",
-                    "payload": {
-                        "name": "Happy Birthday",
-                        "key_signature": "F_MAJOR",
-                        "notes": [
-                            "C_4", "C_4", "D_4", "C_4", "F_4", "E_4",
-                            "C_4", "C_4", "D_4", "C_4", "G_4", "F_4",
-                            "C_4", "C_4", "C_5", "A_4", "F_4", "E_4", "D_4",
-                            "B_FLAT_4", "B_FLAT_4", "A_4", "F_4", "G_4", "F_4"
-                        ],
-                        "mode": "none"
-                    }
-                },
-                {
-                    "text": "Spider Dance",
+                    "text": "Songs",
                     "type": "menu",
                     "items": [
                         {
-                            "text": "Intro",
+                            "text": "Twinkle Twinkle",
                             "type": "scale_drill",
                             "payload": {
-                                "name": "Spider Dance: Intro",
-                                "key_signature": "G_MAJOR",
+                                "name": "Twinkle Twinkle",
+                                "key_signature": "C_MAJOR",
                                 "notes": [
-                                    "D_5", "A_4", "F_SHARP_4", "D_4", "G_SHARP_4",
-                                    "G_4", "F_4", "C_SHARP_4", "C_5", "B_FLAT_3",
-                                    "E_4", "C_SHARP_5"
+                                    "C_4", "C_4", "G_4", "G_4", "A_4", "A_4", "G_4",
+                                    "F_4", "F_4", "E_4", "E_4", "D_4", "D_4", "C_4",
+                                    "G_4", "G_4", "F_4", "F_4", "E_4", "E_4", "D_4",
+                                    "G_4", "G_4", "F_4", "F_4", "E_4", "E_4", "D_4",
+                                    "C_4", "C_4", "G_4", "G_4", "A_4", "A_4", "G_4",
+                                    "F_4", "F_4", "E_4", "E_4", "D_4", "D_4", "C_4"
                                 ],
                                 "mode": "none"
                             }
                         },
                         {
-                            "text": "Theme A",
+                            "text": "Happy Birthday",
                             "type": "scale_drill",
                             "payload": {
-                                "name": "Spider Dance: Theme A",
-                                "key_signature": "G_MAJOR",
+                                "name": "Happy Birthday",
+                                "key_signature": "F_MAJOR",
                                 "notes": [
-                                    "A_5", "G_5", "D_6", "C_SHARP_6", "B_FLAT_5",
-                                    "F_SHARP_5", "D_5", "A_4", "E_5"
+                                    "C_4", "C_4", "D_4", "C_4", "F_4", "E_4",
+                                    "C_4", "C_4", "D_4", "C_4", "G_4", "F_4",
+                                    "C_4", "C_4", "C_5", "A_4", "F_4", "E_4", "D_4",
+                                    "B_FLAT_4", "B_FLAT_4", "A_4", "F_4", "G_4", "F_4"
                                 ],
                                 "mode": "none"
                             }
                         },
                         {
-                            "text": "Climax",
-                            "type": "scale_drill",
-                            "payload": {
-                                "name": "Spider Dance: Climax",
-                                "key_signature": "G_MAJOR",
-                                "notes": [
-                                    "A_5", "D_6", "G_5", "F_SHARP_5",
-                                    "A_FLAT_5", "C_SHARP_5", "A_4", "B_4", "D_5"
-                                ],
-                                "mode": "none"
-                            }
-                        },
-                        {
-                            "text": "Bridge",
-                            "type": "scale_drill",
-                            "payload": {
-                                "name": "Spider Dance: Bridge",
-                                "key_signature": "G_MAJOR",
-                                "notes": [
-                                    "A_5", "F_SHARP_5", "D_5", "G_4", "A_4",
-                                    "B_FLAT_4", "F_SHARP_4", "E_5", "C_SHARP_5",
-                                    "G_5", "F_5", "C_6", "B_FLAT_5"
-                                ],
-                                "mode": "none"
-                            }
-                        },
-                        {
-                            "text": "Pattern I",
-                            "type": "scale_drill",
-                            "payload": {
-                                "name": "Spider Dance: Pattern I",
-                                "key_signature": "G_MAJOR",
-                                "notes": ["G_5", "F_SHARP_5", "D_5", "C_SHARP_5"],
-                                "mode": "none"
-                            }
-                        },
-                        {
-                            "text": "Pattern II",
-                            "type": "scale_drill",
-                            "payload": {
-                                "name": "Spider Dance: Pattern II",
-                                "key_signature": "G_MAJOR",
-                                "notes": ["G_5", "F_SHARP_5", "F_5", "G_SHARP_5", "D_5"],
-                                "mode": "none"
-                            }
+                            "text": "Spider Dance",
+                            "type": "menu",
+                            "items": [
+                                {
+                                    "text": "Intro",
+                                    "type": "scale_drill",
+                                    "payload": {
+                                        "name": "Spider Dance: Intro",
+                                        "key_signature": "G_MAJOR",
+                                        "notes": [
+                                            "D_5", "A_4", "F_SHARP_4", "D_4", "G_SHARP_4",
+                                            "G_4", "F_4", "C_SHARP_4", "C_5", "B_FLAT_3",
+                                            "E_4", "C_SHARP_5"
+                                        ],
+                                        "mode": "none"
+                                    }
+                                },
+                                {
+                                    "text": "Theme A",
+                                    "type": "scale_drill",
+                                    "payload": {
+                                        "name": "Spider Dance: Theme A",
+                                        "key_signature": "G_MAJOR",
+                                        "notes": [
+                                            "A_5", "G_5", "D_6", "C_SHARP_6", "B_FLAT_5",
+                                            "F_SHARP_5", "D_5", "A_4", "E_5"
+                                        ],
+                                        "mode": "none"
+                                    }
+                                },
+                                {
+                                    "text": "Climax",
+                                    "type": "scale_drill",
+                                    "payload": {
+                                        "name": "Spider Dance: Climax",
+                                        "key_signature": "G_MAJOR",
+                                        "notes": [
+                                            "A_5", "D_6", "G_5", "F_SHARP_5",
+                                            "A_FLAT_5", "C_SHARP_5", "A_4", "B_4", "D_5"
+                                        ],
+                                        "mode": "none"
+                                    }
+                                },
+                                {
+                                    "text": "Bridge",
+                                    "type": "scale_drill",
+                                    "payload": {
+                                        "name": "Spider Dance: Bridge",
+                                        "key_signature": "G_MAJOR",
+                                        "notes": [
+                                            "A_5", "F_SHARP_5", "D_5", "G_4", "A_4",
+                                            "B_FLAT_4", "F_SHARP_4", "E_5", "C_SHARP_5",
+                                            "G_5", "F_5", "C_6", "B_FLAT_5"
+                                        ],
+                                        "mode": "none"
+                                    }
+                                },
+                                {
+                                    "text": "Pattern I",
+                                    "type": "scale_drill",
+                                    "payload": {
+                                        "name": "Spider Dance: Pattern I",
+                                        "key_signature": "G_MAJOR",
+                                        "notes": ["G_5", "F_SHARP_5", "D_5", "C_SHARP_5"],
+                                        "mode": "none"
+                                    }
+                                },
+                                {
+                                    "text": "Pattern II",
+                                    "type": "scale_drill",
+                                    "payload": {
+                                        "name": "Spider Dance: Pattern II",
+                                        "key_signature": "G_MAJOR",
+                                        "notes": ["G_5", "F_SHARP_5", "F_5", "G_SHARP_5", "D_5"],
+                                        "mode": "none"
+                                    }
+                                },
+                                {"text": "< Back", "type": "back"}
+                            ]
                         },
                         {"text": "< Back", "type": "back"}
                     ]
                 },
                 {"text": "< Back", "type": "back"}
             ]
+        },
+        {
+            "text": "SONGS",
+            "type": "song"
         },
         {
             "text": "FREE PLAY",

--- a/hardware/saxophone.py
+++ b/hardware/saxophone.py
@@ -13,6 +13,7 @@ import synthio
 import audiomixer
 from adafruit_mcp230xx.mcp23017 import MCP23017
 
+from data.config import Config
 from hardware.breath import BreathSensor
 from hardware.buttons import ButtonHardwareSource, Buttons
 from composer.notes import note_from_mask
@@ -21,7 +22,7 @@ from composer.notes import note_from_mask
 class SaxHardware:
     NOTE_RELEASE_TIME = 0.05
 
-    def __init__(self):
+    def __init__(self, config: Config):
         displayio.release_displays()
 
         # --- Display Setup  ---
@@ -67,7 +68,7 @@ class SaxHardware:
         self.mixer.voice[0].play(self.synth)
 
         # 5. Set Master Volume
-        self.mixer.voice[0].level = 1
+        self.mixer.voice[0].level = config.volume_data.volume
 
         # 6. The Breath (Envelope)
         self.sax_envelope = synthio.Envelope(

--- a/hardware/saxophone.py
+++ b/hardware/saxophone.py
@@ -93,15 +93,13 @@ class SaxHardware:
         self.mcp1_buttons = [btn for btn in Buttons.ALL if btn.hw_source == ButtonHardwareSource.MCP1]
         self.mcp2_buttons = [btn for btn in Buttons.ALL if btn.hw_source == ButtonHardwareSource.MCP2]
 
-        # Initialize the pins for buttons managed by MCP GPIO
-        for btn in self.mcp1_buttons:
-            pin = self.mcp1.get_pin(btn.hw_pin)
-            pin.direction = digitalio.Direction.INPUT
-            pin.pull = digitalio.Pull.UP
-        for btn in self.mcp2_buttons:
-            pin = self.mcp2.get_pin(btn.hw_pin)
-            pin.direction = digitalio.Direction.INPUT
-            pin.pull = digitalio.Pull.UP
+        # Configure all 16 pins on each MCP as input + pullup so calibration can
+        # remap to any pin without re-init, and unmapped pins still read clean.
+        for mcp in (self.mcp1, self.mcp2):
+            for pin_num in range(16):
+                pin = mcp.get_pin(pin_num)
+                pin.direction = digitalio.Direction.INPUT
+                pin.pull = digitalio.Pull.UP
         print("Initialized MCPs")
 
         # initialize the pins for buttons managed by onboard GPIO

--- a/states/calibration_state.py
+++ b/states/calibration_state.py
@@ -1,0 +1,129 @@
+import asyncio
+import os
+
+import terminalio
+from adafruit_display_text import label
+
+from data.config import ButtonPin
+from hardware.buttons import ButtonHardwareSource, Buttons
+from states.play_state import PlayState
+
+CALIBRATE_PATH = "/CALIBRATE"
+
+# Right hand first, then left, then SELECT.
+CALIBRATION_ORDER = (
+    "R_F_SHARP", "R_HIGH_F_SHARP", "R_C", "R_E", "R_1", "R_2", "R_3",
+    "R_B_FLAT", "R_LOW_E_FLAT", "R_LOW_C",
+    "L_OCTAVE", "L_FRONT_F", "L_1", "L_2", "L_3",
+    "L_B_FLAT", "L_D", "L_E_FLAT", "L_F", "L_G_SHARP",
+    "L_LOW_C_SHARP", "L_LOW_B", "L_LOW_B_FLAT",
+    "L_SELECT",
+)
+
+
+def calibrate_requested() -> bool:
+    try:
+        os.stat(CALIBRATE_PATH)
+        return True
+    except OSError:
+        return False
+
+
+class CalibrationState(PlayState):
+    def __init__(self, hw, config):
+        super().__init__(hw, config, title="Calibration")
+        self.config = config
+
+        # Drop the staff — we use that area for prompts.
+        if self.staff in self.ui_group:
+            self.ui_group.remove(self.staff)
+
+        fg = config.color_data.fg_color
+        self.press_label = label.Label(terminalio.FONT, text="Press:", color=fg, scale=1)
+        self.press_label.anchor_point = (0.5, 0.5)
+        self.press_label.anchored_position = (105, 95)
+        self.ui_group.append(self.press_label)
+
+        self.prompt_label = label.Label(terminalio.FONT, text="", color=fg, scale=2)
+        self.prompt_label.anchor_point = (0.5, 0.5)
+        self.prompt_label.anchored_position = (105, 115)
+        self.ui_group.append(self.prompt_label)
+
+        self.progress_label = label.Label(terminalio.FONT, text="", color=fg, scale=1)
+        self.progress_label.anchor_point = (0.5, 1.0)
+        self.progress_label.anchored_position = (105, 230)
+        self.ui_group.append(self.progress_label)
+
+    def _read_grounded_pin(self):
+        """Returns the (hw_source, hw_pin) of the first grounded pin, or None."""
+        gpio1 = self.hw.mcp1.gpio
+        for pin in range(16):
+            if not (gpio1 >> pin) & 1:
+                return (ButtonHardwareSource.MCP1, pin)
+        gpio2 = self.hw.mcp2.gpio
+        for pin in range(16):
+            if not (gpio2 >> pin) & 1:
+                return (ButtonHardwareSource.MCP2, pin)
+        return None
+
+    async def _wait_for_release(self) -> None:
+        while self._read_grounded_pin() is not None:
+            await asyncio.sleep(0.01)
+
+    async def _wait_for_press(self):
+        while True:
+            pressed = self._read_grounded_pin()
+            if pressed is not None:
+                return pressed
+            await asyncio.sleep(0.01)
+
+    async def run(self) -> None:
+        if self.hw.display.root_group != self.ui_group:
+            self.hw.display.root_group = self.ui_group
+        if self.chart_sprite not in self.ui_group:
+            self.ui_group.append(self.chart_sprite)
+
+        used = set()
+        total = len(CALIBRATION_ORDER)
+
+        for index, name in enumerate(CALIBRATION_ORDER):
+            button = getattr(Buttons, name)
+            self.prompt_label.text = name
+            self.progress_label.text = f"{index + 1} / {total}"
+
+            if button.bounding_box is not None:
+                await self.blit_specific_fingering((button,))
+            self.hw.display.refresh()
+
+            await self._wait_for_release()
+
+            while True:
+                pressed = await self._wait_for_press()
+                if pressed not in used:
+                    break
+                # Duplicate — prompt and wait for them to release + try again.
+                self.prompt_label.text = "DUPE-" + name
+                self.hw.display.refresh()
+                await self._wait_for_release()
+                self.prompt_label.text = name
+                self.hw.display.refresh()
+
+            hw_source, hw_pin = pressed
+            setattr(self.config.button_data, name, ButtonPin(hw_source, hw_pin))
+            used.add(pressed)
+
+            await self._wait_for_release()
+            if button.bounding_box is not None:
+                await self.clear_specific_fingering((button,))
+
+        self.config.persist()
+        Buttons.apply_config(self.config.button_data)
+        try:
+            os.remove(CALIBRATE_PATH)
+        except OSError as e:
+            print(f"Could not remove {CALIBRATE_PATH}: {e}")
+
+        self.prompt_label.text = "Done!"
+        self.progress_label.text = ""
+        self.hw.display.refresh()
+        await asyncio.sleep(1.5)

--- a/states/scale_drill_state.py
+++ b/states/scale_drill_state.py
@@ -51,7 +51,9 @@ class ScaleDrillState(PlayState):
 
         notes_to_add = []
         if self.mode == "rand":
-            notes_to_add = random.sample(self.notes, len(self.notes))
+            # CircuitPython has no random.sample/choices — use random.choice per slot.
+            # Picks with replacement, so the same note can repeat freely.
+            notes_to_add = [random.choice(self.notes) for _ in range(len(self.notes))]
         elif self.mode == "reverse":
             notes_to_add = list(reversed(self.notes))
             notes_to_add.pop(0)

--- a/states/song_state.py
+++ b/states/song_state.py
@@ -27,6 +27,8 @@ class SongState(PlayState):
         # Initially, show the selectable list UI instead of PlayState UI
         self.hw.display.root_group = self.selectable_list.ui_group
 
+        self.hw.mixer.voice[1].level = config.volume_data.volume
+
     @staticmethod
     def _get_song_list():
         try:
@@ -83,7 +85,6 @@ class SongState(PlayState):
             # to guarantee the file handle is cleaned up when we exit this song.
             with open(selected_song['file'], "rb") as mp3_file:
                 decoder = audiomp3.MP3Decoder(mp3_file, SongState.AUDIO_BUFFER)
-                self.hw.mixer.voice[1].level = 0.3
                 self.hw.mixer.voice[1].play(decoder)
                 
                 # Reset PlayState's running flag in case we played a song previously


### PR DESCRIPTION
Write a file "CALIBRATE" to the root of the filesystem, and on startup it will send you to a button calibration. A shortcut for this 'make calibrate' will write the file when connected to your system.

 This will highlight each button on the fingering chart one by one, asking you to press this button and learning which hardware pin it is connected to.

Also restore the 'songs' menu to play MP3s, and move the practice to drills->songs

Fixes #29 