### PR TITLE
feat: add metronome, enable/disable timed drills

### DIFF
--- a/code.py
+++ b/code.py
@@ -12,6 +12,12 @@ from data.config import Config
 async def main():
     config = Config.load_config()
 
+    # Seed the live drill mode from the persisted default. The ready-screen
+    # toggle in ScaleDrillState mutates SESSION_MODE for the rest of the
+    # session; this restores it on boot.
+    from states.scale_drill_state import ScaleDrillState
+    ScaleDrillState.SESSION_MODE = config.drill_data.default_mode
+
     hw = SaxHardware(config)
     await hw.start_hardware()
 

--- a/composer/staff.py
+++ b/composer/staff.py
@@ -49,9 +49,9 @@ class Staff(displayio.Group):
         "F": 7,
     }
 
-    # --- Note sprite sheet layout (150x96, 30x48 tiles) ---
-    # Top row: eighth(0), quarter(1), half(2), whole(3)
-    # Bottom row: eighth rest(5), quarter rest(6), half rest(7), whole rest(8)
+    # --- Note sprite sheet layout (120x96, 30x48 tiles, 4 cols x 2 rows) ---
+    # Top row:    eighth(0), quarter(1), half(2), whole(3)
+    # Bottom row: eighth rest(4), quarter rest(5), half rest(6), whole rest(7)
     NOTE_SHEET_PATH = "data/img/note_sprite_sheet.png"
     NOTE_SPRITE_WIDTH = 30
     NOTE_SPRITE_HEIGHT = 48
@@ -79,10 +79,10 @@ class Staff(displayio.Group):
     }
 
     REST_TILE = {
-        Duration.EIGHTH:  5,
-        Duration.QUARTER: 6,
-        Duration.HALF:    7,
-        Duration.WHOLE:   8,
+        Duration.EIGHTH:  4,
+        Duration.QUARTER: 5,
+        Duration.HALF:    6,
+        Duration.WHOLE:   7,
     }
     # Pixel within the rest sprite that should land on REST_LEDGER_LINE.
     REST_PIN_Y = 24
@@ -123,9 +123,11 @@ class Staff(displayio.Group):
         self._note_pool = []
         self._acc_pool = []
         self._ledger_pool = []
+        self._measure_line_pool = []
         self._note_pool_next = 0
         self._acc_pool_next = 0
         self._ledger_pool_next = 0
+        self._measure_line_pool_next = 0
 
         # Progress-overlay state. Allocated only when enable_progress=True;
         # otherwise these stay None and Staff behaves exactly as before.
@@ -304,6 +306,25 @@ class Staff(displayio.Group):
             self._ledger_pool.append(tg)
             self.dynamic_group.append(tg)
 
+        # Measure-line pool — vertical lines drawn at 4-beat boundaries within
+        # the layout. Sized to span exactly the 5-line staff (top of line 0
+        # through bottom of line 4 inclusive). Lives in static_group alongside
+        # the staff lines: same z-layer (measure lines render behind notes,
+        # matching music-notation convention), and on overlay staves whose
+        # static_group is popped (drill_staff in ScaleDrillState) these get
+        # cleared out the same way the staff lines do — so measure lines only
+        # ever exist on the staff that draws the actual lines.
+        measure_line_height = 4 * self.LEDGER_SPACING + 1
+        measure_bitmap = displayio.Bitmap(1, measure_line_height, 1)
+        measure_palette = displayio.Palette(1)
+        measure_palette[0] = self.config.color_data.fg_color
+        for _ in range(4):  # 4 verticals is plenty for any reasonable window
+            tg = displayio.TileGrid(measure_bitmap, pixel_shader=measure_palette)
+            tg.x = -1000
+            tg.y = -1000
+            self._measure_line_pool.append(tg)
+            self.static_group.append(tg)
+
     def _init_progress_overlay(self) -> None:
         """Allocates two 30x48 bitmaps for progressive note fill:
         - overlay: the on-screen target. Mutated incrementally — never wholesale
@@ -394,6 +415,9 @@ class Staff(displayio.Group):
         Items are centered within their beat-proportional horizontal slots so that,
         for example, a whole note sits in the middle of the measure rather than the
         far-left edge.  Assumes 4/4 time (4 beats per measure).
+
+        Measure lines are no longer drawn here — call `set_measure_lines`
+        separately, on whichever staff should own them.
         """
         for tg in self._note_pool:
             tg.x = -1000
@@ -431,6 +455,46 @@ class Staff(displayio.Group):
                 self._draw_timed_note(item, slot_cx)
 
             current_beat += beats
+
+    def set_measure_lines(self, items, start_beat: float = 0) -> None:
+        """Places measure lines for the given item sequence's layout without
+        touching the note pool. Call this separately from update_sequence so
+        the lines can live on a different staff than the notes (overlay
+        pattern: notes on drill_staff, measure lines on the base staff so
+        they inherit its un-overridden fg_color)."""
+        for tg in self._measure_line_pool:
+            tg.x = -1000
+        self._measure_line_pool_next = 0
+
+        num_ks_acc = len(self.key_signature.accidentals) if self.key_signature else 0
+        content_x = 32 + (num_ks_acc * self.ACC_SPRITE_WIDTH) + 8
+        available_w = self.width - content_x - 4
+        beats_per_measure = 4
+        beat_w = available_w / beats_per_measure
+
+        total_layout_beats = 0
+        for item in items:
+            total_layout_beats += self.DURATION_BEATS.get(item.duration, 1)
+
+        self._draw_measure_lines(start_beat, total_layout_beats, content_x, beat_w, beats_per_measure)
+
+    def _draw_measure_lines(self, start_beat, total_layout_beats, content_x, beat_w, beats_per_measure):
+        """Places measure-line TileGrids at every 4-beat boundary that falls
+        strictly inside the layout's beat range (not at the leftmost edge)."""
+        # First multiple of beats_per_measure at or after start_beat:
+        n = int((start_beat + beats_per_measure - 1) // beats_per_measure)
+        while True:
+            boundary_global = n * beats_per_measure
+            boundary_layout = boundary_global - start_beat
+            if boundary_layout > total_layout_beats:
+                break
+            if boundary_layout > 0:  # don't draw at the leftmost edge
+                if self._measure_line_pool_next < len(self._measure_line_pool):
+                    line_tg = self._measure_line_pool[self._measure_line_pool_next]
+                    line_tg.x = int(content_x + boundary_layout * beat_w)
+                    line_tg.y = self.staff_y_start
+                    self._measure_line_pool_next += 1
+            n += 1
 
     def _draw_timed_note(self, timed_note: TimedNote, slot_cx: int) -> None:
         note = timed_note.note

--- a/data/config.py
+++ b/data/config.py
@@ -50,6 +50,7 @@ class Config:
     def __init__(self):
         self.color_data = ColorConfig()
         self.volume_data = VolumeConfig()
+        self.drill_data = DrillConfig()
         self.button_data = ButtonConfig()
 
     @classmethod
@@ -88,7 +89,7 @@ class ColorConfig:
 
 class VolumeConfig:
     # Allowed levels: 1% floor, then 10% steps up to 100%.
-    LEVELS = [0.01, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    LEVELS = [0.01, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 1.0]
 
     def __init__(self, volume=0.3):
         self.volume = volume
@@ -107,6 +108,45 @@ class VolumeConfig:
 
     def percent(self):
         return int(round(self.volume * 100))
+
+
+class DrillConfig:
+    """Persisted defaults for drill timing. Used by ScaleDrillState at startup;
+    the live session value (ScaleDrillState.SESSION_MODE) is seeded from
+    `default_mode` on boot and may diverge mid-session via the ready-screen
+    toggle. The Drill settings screen writes both back at the same time.
+
+    Owns the canonical MODE_TIMED / MODE_EASY constants — ScaleDrillState
+    re-exports them so callers don't need to import data.config to compare
+    against a mode value."""
+
+    MODE_TIMED = "timed"
+    MODE_EASY = "easy"
+    MODES = (MODE_TIMED, MODE_EASY)
+
+    BPM_STEP = 2
+    BPM_MIN = 40
+    BPM_MAX = 160
+
+    def __init__(self, default_bpm=48, default_mode=MODE_TIMED, hold_factor=0.75):
+        self.default_bpm = default_bpm
+        self.default_mode = default_mode
+        # Fraction of musical duration that counts as fully satisfied — the
+        # remaining (1 - hold_factor) is breathing room. Used for both fill
+        # display (reaches 100% at this point) and timed-mode scoring.
+        self.hold_factor = hold_factor
+
+    def step_bpm_up(self):
+        self.default_bpm = min(self.default_bpm + self.BPM_STEP, self.BPM_MAX)
+
+    def step_bpm_down(self):
+        self.default_bpm = max(self.default_bpm - self.BPM_STEP, self.BPM_MIN)
+
+    def toggle_mode(self):
+        self.default_mode = (
+            DrillConfig.MODE_EASY if self.default_mode == DrillConfig.MODE_TIMED
+            else DrillConfig.MODE_TIMED
+        )
 
 
 class ButtonPin:

--- a/data/menu_config.py
+++ b/data/menu_config.py
@@ -1,425 +1,187 @@
-MAIN_MENU = {
-    "title": "MAIN MENU", # Only the root needs an explicit title
-    "type": "menu",
-    "items": [
-        {
-            "text": "DRILLS",
-            "type": "menu",
-            "items": [
-                {
-                    "text": "Scales",
-                    "type": "menu",
-                    "items": [
-                        {
-                            "text": "Major Scales",
-                            "type": "menu",
-                            "items": [
-                                {
-                                    "text": "C Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "C Major",
-                                        "key_signature": "C_MAJOR",
-                                        "notes": ["C_4", "D_4", "E_4", "F_4", "G_4", "A_4", "B_4", "C_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "F Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "F Major",
-                                        "key_signature": "F_MAJOR",
-                                        "notes": ["F_4", "G_4", "A_4", "B_FLAT_4", "C_5", "D_5", "E_5", "F_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "Bb Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Bb Major",
-                                        "key_signature": "B_FLAT_MAJOR",
-                                        "notes": ["B_FLAT_4", "C_5", "D_5", "E_FLAT_5", "F_5", "G_5", "A_5", "B_FLAT_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "Eb Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Eb Major",
-                                        "key_signature": "E_FLAT_MAJOR",
-                                        "notes": ["E_FLAT_4", "F_4", "G_4", "A_FLAT_4", "B_FLAT_4", "C_5", "D_5", "E_FLAT_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "Ab Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Ab Major",
-                                        "key_signature": "A_FLAT_MAJOR",
-                                        "notes": ["A_FLAT_4", "B_FLAT_4", "C_5", "D_FLAT_5", "E_FLAT_5", "F_5", "G_5", "A_FLAT_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "Db Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Db Major",
-                                        "key_signature": "D_FLAT_MAJOR",
-                                        "notes": ["D_FLAT_4", "E_FLAT_4", "F_4", "G_FLAT_4", "A_FLAT_4", "B_FLAT_4", "C_5", "D_FLAT_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "Gb Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Gb Major",
-                                        "key_signature": "G_FLAT_MAJOR",
-                                        "notes": ["G_FLAT_4", "A_FLAT_4", "B_FLAT_4", "C_FLAT_5", "D_FLAT_5", "E_FLAT_5", "F_5", "G_FLAT_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "B Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "B Major",
-                                        "key_signature": "B_MAJOR",
-                                        "notes": ["B_4", "C_SHARP_5", "D_SHARP_5", "E_5", "F_SHARP_5", "G_SHARP_5", "A_SHARP_5", "B_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "E Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "E Major",
-                                        "key_signature": "E_MAJOR",
-                                        "notes": ["E_4", "F_SHARP_4", "G_SHARP_4", "A_4", "B_4", "C_SHARP_5", "D_SHARP_5", "E_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "A Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "A Major",
-                                        "key_signature": "A_MAJOR",
-                                        "notes": ["A_4", "B_4", "C_SHARP_5", "D_5", "E_5", "F_SHARP_5", "G_SHARP_5", "A_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "D Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "D Major",
-                                        "key_signature": "D_MAJOR",
-                                        "notes": ["D_4", "E_4", "F_SHARP_4", "G_4", "A_4", "B_4", "C_SHARP_5", "D_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {
-                                    "text": "G Major Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "G Major",
-                                        "key_signature": "G_MAJOR",
-                                        "notes": ["G_4", "A_4", "B_4", "C_5", "D_5", "E_5", "F_SHARP_5", "G_5"],
-                                        "mode": "revrand"
-                                    }
-                                },
-                                {"text": "< Back", "type": "back"}
-                            ]
-                        },
-                        {
-                            "text": "Blues Scales",
-                            "type": "menu",
-                            "items": [
-                                {
-                                    "text": "C Blues Scale (basic)",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "C Blues",
-                                        "key_signature": "C_MAJOR",
-                                        "notes": ["C_4", "E_FLAT_4", "F_4", "F_SHARP_4", "G_4", "B_FLAT_4", "C_5", "B_FLAT_4", "G_4", "F_SHARP_4", "F_4", "E_FLAT_4", "C_4"]
-                                    }
-                                },
-                                {
-                                    "text": "C Blues Scale",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "C Blues",
-                                        "key_signature": "C_MAJOR",
-                                        "notes": ["C_4", "E_FLAT_4", "F_4", "E_FLAT_4", "F_4", "F_SHARP_4","F_4", "F_SHARP_4",
-                                                  "G_4", "F_SHARP_4", "G_4", "B_FLAT_4", "G_4", "B_FLAT_4", "C_5", "B_FLAT_4",
-                                                  "G_4", "B_FLAT_4", "G_4", "F_SHARP_4", "G_4", "F_SHARP_4", "F_4", "F_SHARP_4",
-                                                  "F_4", "E_FLAT_4", "C_4"]
-                                    }
-                                },
-                                {"text": "< Back", "type": "back"}
-                            ]
-                        },
-                        {
-                            "text": "Thirds Scales",
-                            "type": "menu",
-                            "items": [
-                                {
-                                    "text": "C Major Thirds",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "C Major Thirds",
-                                        "key_signature": "C_MAJOR",
-                                        "notes": ["C_4", "E_4", "D_4", "F_4", "E_4", "G_4", "F_4", "A_4", "G_4", "B_4", "A_4",
-                                                  "C_5", "B_4", "D_5", "C_5", "REST_QUARTER", "E_5", "C_5", "D_5", "B_4", "C_5", "A_4", "B_4",
-                                                  "G_4", "A_4", "F_4", "G_4", "E_4", "F_4", "D_4", "C_4"],
-                                        "mode": "none"
-                                    }
-                                },
-                                {
-                                    "text": "F Major Thirds",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "F Major Thirds",
-                                        "key_signature": "F_MAJOR",
-                                        "notes": ["F_4", "A_4", "G_4", "B_FLAT_4", "A_4", "C_5", "B_FLAT_4", "D_5", "C_5",
-                                                  "E_5", "D_5", "F_5", "E_5", "G_5", "F_5", "REST_QUARTER", "A_5", "F_5", "G_5", "E_5",
-                                                  "F_5", "D_5", "E_5", "C_5", "D_5", "B_FLAT_4", "C_5", "A_4", "B_FLAT_4",
-                                                  "G_4", "F_4"],
-                                        "mode": "none"
-                                    }
-                                },
-                                {"text": "< Back", "type": "back"}
-                            ]
-                        },
-                        {"text": "< Back", "type": "back"}
-                    ]
-                },
-                {
-                    "text": "Songs",
-                    "type": "menu",
-                    "items": [
-                        {
-                            "text": "Battle Cats theme",
-                            "type": "scale_drill",
-                            "payload": {
-                                "name": "Battle Cats theme",
-                                "key_signature": "C_MINOR",
-                                "bpm": 96,
-                                "notes": [
-                                    "C_4", "REST_HALF", "C_4", "E_FLAT_4", "C_4", "F_SHARP_4", "G_4",
-                                    "REST_HALF", "C_4", "E_FLAT_4", "F_SHARP_4", "G_4:EIGHTH", "G_4:EIGHTH",
-                                    "F_4:EIGHTH", "F_4:EIGHTH", "E_FLAT_4:EIGHTH", "E_FLAT_4:EIGHTH", "C_4:EIGHTH",
-                                    "C_4:EIGHTH", "E_FLAT_4:EIGHTH", "C_4", "REST_HALF", "B_FLAT_3", "D_4"
-                                ],
-                                "mode": "none"
-                            }
-                        },
-                        {
-                            "text": "Twinkle Twinkle",
-                            "type": "scale_drill",
-                            "payload": {
-                                "name": "Twinkle Twinkle",
-                                "key_signature": "C_MAJOR",
-                                "notes": [
-                                    "C_4", "C_4", "G_4", "G_4", "A_4", "A_4", "G_4",
-                                    "F_4", "F_4", "E_4", "E_4", "D_4", "D_4", "C_4",
-                                    "G_4", "G_4", "F_4", "F_4", "E_4", "E_4", "D_4",
-                                    "G_4", "G_4", "F_4", "F_4", "E_4", "E_4", "D_4",
-                                    "C_4", "C_4", "G_4", "G_4", "A_4", "A_4", "G_4",
-                                    "F_4", "F_4", "E_4", "E_4", "D_4", "D_4", "C_4"
-                                ],
-                                "mode": "none"
-                            }
-                        },
-                        {
-                            "text": "Happy Birthday",
-                            "type": "scale_drill",
-                            "payload": {
-                                "name": "Happy Birthday",
-                                "key_signature": "F_MAJOR",
-                                "notes": [
-                                    "C_4", "C_4", "D_4", "C_4", "F_4", "E_4",
-                                    "C_4", "C_4", "D_4", "C_4", "G_4", "F_4",
-                                    "C_4", "C_4", "C_5", "A_4", "F_4", "E_4", "D_4",
-                                    "B_FLAT_4", "B_FLAT_4", "A_4", "F_4", "G_4", "F_4"
-                                ],
-                                "mode": "none"
-                            }
-                        },
-                        {
-                            "text": "Spider Dance",
-                            "type": "menu",
-                            "items": [
-                                {
-                                    "text": "Intro",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Spider Dance: Intro",
-                                        "key_signature": "G_MAJOR",
-                                        "notes": [
-                                            "D_5", "A_4", "F_SHARP_4", "D_4", "G_SHARP_4",
-                                            "G_4", "F_4", "C_SHARP_4", "C_5", "B_FLAT_3",
-                                            "E_4", "C_SHARP_5"
-                                        ],
-                                        "mode": "none"
-                                    }
-                                },
-                                {
-                                    "text": "Theme A",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Spider Dance: Theme A",
-                                        "key_signature": "G_MAJOR",
-                                        "notes": [
-                                            "A_5", "G_5", "D_6", "C_SHARP_6", "B_FLAT_5",
-                                            "F_SHARP_5", "D_5", "A_4", "E_5"
-                                        ],
-                                        "mode": "none"
-                                    }
-                                },
-                                {
-                                    "text": "Climax",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Spider Dance: Climax",
-                                        "key_signature": "G_MAJOR",
-                                        "notes": [
-                                            "A_5", "D_6", "G_5", "F_SHARP_5",
-                                            "A_FLAT_5", "C_SHARP_5", "A_4", "B_4", "D_5"
-                                        ],
-                                        "mode": "none"
-                                    }
-                                },
-                                {
-                                    "text": "Bridge",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Spider Dance: Bridge",
-                                        "key_signature": "G_MAJOR",
-                                        "notes": [
-                                            "A_5", "F_SHARP_5", "D_5", "G_4", "A_4",
-                                            "B_FLAT_4", "F_SHARP_4", "E_5", "C_SHARP_5",
-                                            "G_5", "F_5", "C_6", "B_FLAT_5"
-                                        ],
-                                        "mode": "none"
-                                    }
-                                },
-                                {
-                                    "text": "Pattern I",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Spider Dance: Pattern I",
-                                        "key_signature": "G_MAJOR",
-                                        "notes": ["G_5", "F_SHARP_5", "D_5", "C_SHARP_5"],
-                                        "mode": "none"
-                                    }
-                                },
-                                {
-                                    "text": "Pattern II",
-                                    "type": "scale_drill",
-                                    "payload": {
-                                        "name": "Spider Dance: Pattern II",
-                                        "key_signature": "G_MAJOR",
-                                        "notes": ["G_5", "F_SHARP_5", "F_5", "G_SHARP_5", "D_5"],
-                                        "mode": "none"
-                                    }
-                                },
-                                {"text": "< Back", "type": "back"}
-                            ]
-                        },
-                        {"text": "< Back", "type": "back"}
-                    ]
-                },
-                {"text": "< Back", "type": "back"}
-            ]
+def menu(text, items, back=True):
+    """Wraps items into a menu node. Auto-injects '< Back' at the bottom unless
+    back=False (use back=False for the root menu, which has no parent)."""
+    items_list = list(items)
+    if back:
+        items_list.append({"text": "< Back", "type": "back"})
+    return {"text": text, "type": "menu", "items": items_list}
+
+
+def drill(text, key_signature, notes, name=None, mode=None, bpm=None):
+    """Builds a scale_drill menu entry. name defaults to text since most drills
+    use the same string for both; pass name= when they should differ (e.g. scale
+    items where text is 'C Major Scale' but name is 'C Major')."""
+    payload = {
+        "name": text if name is None else name,
+        "key_signature": key_signature,
+        "notes": notes,
+    }
+    if mode is not None:
+        payload["mode"] = mode
+    if bpm is not None:
+        payload["bpm"] = bpm
+    return {"text": text, "type": "scale_drill", "payload": payload}
+
+
+def color(text, bg_color, fg_color, chart_color, fingering_color, drill_note_color, name=None):
+    """Builds a color-theme menu entry. name defaults to text."""
+    return {
+        "text": text,
+        "type": "color",
+        "payload": {
+            "name": text if name is None else name,
+            "bg_color": bg_color,
+            "fg_color": fg_color,
+            "chart_color": chart_color,
+            "fingering_color": fingering_color,
+            "drill_note_color": drill_note_color,
         },
-        {
-            "text": "SONGS",
-            "type": "song"
-        },
-        {
-            "text": "FREE PLAY",
-            "type": "play"
-        },
-        {
-            "text": "SETTINGS",
-            "type": "menu",
-            "items": [
-                {
-                    "text": "Color",
-                    "type": "menu",
-                    "items": [
-                        {"text": "Hulk", "type": "color", "payload": {
-                            "name": "Hulk",
-                            "bg_color": 0x000000,
-                            "fg_color": 0x00FE03,
-                            "chart_color": 0x00FE03,
-                            "fingering_color": 0xFF01FC,
-                            "drill_note_color": 0xFF6000
-                        }},
-                        {"text": "Christmas", "type": "color", "payload": {
-                            "name": "Christmas",
-                            "bg_color": 0xFF2222,
-                            "fg_color": 0x00DD00,
-                            "chart_color": 0x00DD00,
-                            "fingering_color": 0xFFFF80,
-                            "drill_note_color": 0xCCCCCC
-                        }},
-                        {"text": "Default", "type": "color", "payload": {
-                            "name": "Default",
-                            "bg_color": 0x0000FF,
-                            "fg_color": 0xFFFFFF,
-                            "chart_color": 0xFFFFFF,
-                            "fingering_color": 0xFF0000,
-                            "drill_note_color": 0x00FF00
-                        }},
-                        {"text": "Solarized Dark", "type": "color", "payload": {
-                            "name": "Solarized Dark",
-                            "bg_color": 0x002B36,
-                            "fg_color": 0x93A1A1,
-                            "chart_color": 0x93A1A1,
-                            "fingering_color": 0xB58900,
-                            "drill_note_color": 0x2AA198
-                        }},
-                        {"text": "Dracula", "type": "color", "payload": {
-                            "name": "Dracula",
-                            "bg_color": 0x282A36,
-                            "fg_color": 0xF8F8F2,
-                            "chart_color": 0xF8F8F2,
-                            "fingering_color": 0xFF79C6,
-                            "drill_note_color": 0x50FA7B
-                        }},
-                        {"text": "Gruvbox Dark", "type": "color", "payload": {
-                            "name": "Gruvbox Dark",
-                            "bg_color": 0x282828,
-                            "fg_color": 0xEBDBB2,
-                            "chart_color": 0xEBDBB2,
-                            "fingering_color": 0xFE8019,
-                            "drill_note_color": 0xB8BB26
-                        }},
-                        {"text": "Monokai", "type": "color", "payload": {
-                            "name": "Monokai",
-                            "bg_color": 0x272822,
-                            "fg_color": 0xF8F8F2,
-                            "chart_color": 0xF8F8F2,
-                            "fingering_color": 0xF92672,
-                            "drill_note_color": 0xA6E22E
-                        }},
-                        {"text": "> Back", "type": "back"}
-                    ]
-                },
-                {
-                    "text": "Volume",
-                    "type": "volume_settings"
-                },
-                {"text": "< Back", "type": "back"}
-            ]
-        }
-    ]
-}
+    }
+
+
+MAIN_MENU = menu("MAIN MENU", back=False, items=[
+    menu("DRILLS", [
+        menu("Scales", [
+            menu("Major Scales", [
+                drill("C Major Scale",  "C_MAJOR",
+                      ["C_4", "D_4", "E_4", "F_4", "G_4", "A_4", "B_4", "C_5"],
+                      name="C Major", mode="revrand"),
+                drill("F Major Scale",  "F_MAJOR",
+                      ["F_4", "G_4", "A_4", "B_FLAT_4", "C_5", "D_5", "E_5", "F_5"],
+                      name="F Major", mode="revrand"),
+                drill("Bb Major Scale", "B_FLAT_MAJOR",
+                      ["B_FLAT_4", "C_5", "D_5", "E_FLAT_5", "F_5", "G_5", "A_5", "B_FLAT_5"],
+                      name="Bb Major", mode="revrand"),
+                drill("Eb Major Scale", "E_FLAT_MAJOR",
+                      ["E_FLAT_4", "F_4", "G_4", "A_FLAT_4", "B_FLAT_4", "C_5", "D_5", "E_FLAT_5"],
+                      name="Eb Major", mode="revrand"),
+                drill("Ab Major Scale", "A_FLAT_MAJOR",
+                      ["A_FLAT_4", "B_FLAT_4", "C_5", "D_FLAT_5", "E_FLAT_5", "F_5", "G_5", "A_FLAT_5"],
+                      name="Ab Major", mode="revrand"),
+                drill("Db Major Scale", "D_FLAT_MAJOR",
+                      ["D_FLAT_4", "E_FLAT_4", "F_4", "G_FLAT_4", "A_FLAT_4", "B_FLAT_4", "C_5", "D_FLAT_5"],
+                      name="Db Major", mode="revrand"),
+                drill("Gb Major Scale", "G_FLAT_MAJOR",
+                      ["G_FLAT_4", "A_FLAT_4", "B_FLAT_4", "C_FLAT_5", "D_FLAT_5", "E_FLAT_5", "F_5", "G_FLAT_5"],
+                      name="Gb Major", mode="revrand"),
+                drill("B Major Scale",  "B_MAJOR",
+                      ["B_4", "C_SHARP_5", "D_SHARP_5", "E_5", "F_SHARP_5", "G_SHARP_5", "A_SHARP_5", "B_5"],
+                      name="B Major", mode="revrand"),
+                drill("E Major Scale",  "E_MAJOR",
+                      ["E_4", "F_SHARP_4", "G_SHARP_4", "A_4", "B_4", "C_SHARP_5", "D_SHARP_5", "E_5"],
+                      name="E Major", mode="revrand"),
+                drill("A Major Scale",  "A_MAJOR",
+                      ["A_4", "B_4", "C_SHARP_5", "D_5", "E_5", "F_SHARP_5", "G_SHARP_5", "A_5"],
+                      name="A Major", mode="revrand"),
+                drill("D Major Scale",  "D_MAJOR",
+                      ["D_4", "E_4", "F_SHARP_4", "G_4", "A_4", "B_4", "C_SHARP_5", "D_5"],
+                      name="D Major", mode="revrand"),
+                drill("G Major Scale",  "G_MAJOR",
+                      ["G_4", "A_4", "B_4", "C_5", "D_5", "E_5", "F_SHARP_5", "G_5"],
+                      name="G Major", mode="revrand"),
+            ]),
+            menu("Blues Scales", [
+                drill("C Blues Scale (basic)", "C_MAJOR",
+                      ["C_4", "E_FLAT_4", "F_4", "F_SHARP_4", "G_4", "B_FLAT_4", "C_5",
+                       "B_FLAT_4", "G_4", "F_SHARP_4", "F_4", "E_FLAT_4", "C_4"],
+                      name="C Blues"),
+                drill("C Blues Scale", "C_MAJOR",
+                      ["C_4", "E_FLAT_4", "F_4", "E_FLAT_4", "F_4", "F_SHARP_4", "F_4", "F_SHARP_4",
+                       "G_4", "F_SHARP_4", "G_4", "B_FLAT_4", "G_4", "B_FLAT_4", "C_5", "B_FLAT_4",
+                       "G_4", "B_FLAT_4", "G_4", "F_SHARP_4", "G_4", "F_SHARP_4", "F_4", "F_SHARP_4",
+                       "F_4", "E_FLAT_4", "C_4"],
+                      name="C Blues"),
+            ]),
+            menu("Thirds Scales", [
+                drill("C Major Thirds", "C_MAJOR",
+                      ["C_4", "E_4", "D_4", "F_4", "E_4", "G_4", "F_4", "A_4", "G_4", "B_4", "A_4",
+                       "C_5", "B_4", "D_5", "C_5", "REST_QUARTER", "E_5", "C_5", "D_5", "B_4", "C_5", "A_4", "B_4",
+                       "G_4", "A_4", "F_4", "G_4", "E_4", "F_4", "D_4", "C_4"],
+                      mode="none"),
+                drill("F Major Thirds", "F_MAJOR",
+                      ["F_4", "A_4", "G_4", "B_FLAT_4", "A_4", "C_5", "B_FLAT_4", "D_5", "C_5",
+                       "E_5", "D_5", "F_5", "E_5", "G_5", "F_5", "REST_QUARTER", "A_5", "F_5", "G_5", "E_5",
+                       "F_5", "D_5", "E_5", "C_5", "D_5", "B_FLAT_4", "C_5", "A_4", "B_FLAT_4",
+                       "G_4", "F_4"],
+                      mode="none"),
+            ]),
+        ]),
+        menu("Songs", [
+            drill("Battle Cats theme", "C_MINOR",
+                  ["C_4", "REST_HALF", "C_4", "E_FLAT_4", "C_4", "F_SHARP_4", "G_4",
+                   "REST_HALF", "C_4", "E_FLAT_4", "F_SHARP_4", "G_4:EIGHTH", "G_4:EIGHTH",
+                   "F_4:EIGHTH", "F_4:EIGHTH", "E_FLAT_4:EIGHTH", "E_FLAT_4:EIGHTH", "C_4:EIGHTH",
+                   "C_4:EIGHTH", "E_FLAT_4:EIGHTH", "C_4", "REST_HALF", "B_FLAT_3", "D_4"],
+                  mode="none", bpm=96),
+            drill("Twinkle Twinkle", "C_MAJOR",
+                  ["C_4", "C_4", "G_4", "G_4", "A_4", "A_4", "G_4",
+                   "F_4", "F_4", "E_4", "E_4", "D_4", "D_4", "C_4",
+                   "G_4", "G_4", "F_4", "F_4", "E_4", "E_4", "D_4",
+                   "G_4", "G_4", "F_4", "F_4", "E_4", "E_4", "D_4",
+                   "C_4", "C_4", "G_4", "G_4", "A_4", "A_4", "G_4",
+                   "F_4", "F_4", "E_4", "E_4", "D_4", "D_4", "C_4"],
+                  mode="none"),
+            drill("Happy Birthday", "F_MAJOR",
+                  ["C_4", "C_4", "D_4", "C_4", "F_4", "E_4",
+                   "C_4", "C_4", "D_4", "C_4", "G_4", "F_4",
+                   "C_4", "C_4", "C_5", "A_4", "F_4", "E_4", "D_4",
+                   "B_FLAT_4", "B_FLAT_4", "A_4", "F_4", "G_4", "F_4"],
+                  mode="none"),
+            menu("Spider Dance", [
+                drill("Intro", "G_MAJOR",
+                      ["D_5", "A_4", "F_SHARP_4", "D_4", "G_SHARP_4",
+                       "G_4", "F_4", "C_SHARP_4", "C_5", "B_FLAT_3",
+                       "E_4", "C_SHARP_5"],
+                      name="Spider Dance: Intro", mode="none"),
+                drill("Theme A", "G_MAJOR",
+                      ["A_5", "G_5", "D_6", "C_SHARP_6", "B_FLAT_5",
+                       "F_SHARP_5", "D_5", "A_4", "E_5"],
+                      name="Spider Dance: Theme A", mode="none"),
+                drill("Climax", "G_MAJOR",
+                      ["A_5", "D_6", "G_5", "F_SHARP_5",
+                       "A_FLAT_5", "C_SHARP_5", "A_4", "B_4", "D_5"],
+                      name="Spider Dance: Climax", mode="none"),
+                drill("Bridge", "G_MAJOR",
+                      ["A_5", "F_SHARP_5", "D_5", "G_4", "A_4",
+                       "B_FLAT_4", "F_SHARP_4", "E_5", "C_SHARP_5",
+                       "G_5", "F_5", "C_6", "B_FLAT_5"],
+                      name="Spider Dance: Bridge", mode="none"),
+                drill("Pattern I", "G_MAJOR",
+                      ["G_5", "F_SHARP_5", "D_5", "C_SHARP_5"],
+                      name="Spider Dance: Pattern I", mode="none"),
+                drill("Pattern II", "G_MAJOR",
+                      ["G_5", "F_SHARP_5", "F_5", "G_SHARP_5", "D_5"],
+                      name="Spider Dance: Pattern II", mode="none"),
+            ]),
+        ]),
+    ]),
+    {"text": "SONGS", "type": "song"},
+    {"text": "FREE PLAY", "type": "play"},
+    menu("SETTINGS", [
+        menu("Color", [
+            color("Hulk",
+                  bg_color=0x000000, fg_color=0x00FE03, chart_color=0x00FE03,
+                  fingering_color=0xFF01FC, drill_note_color=0xFF6000),
+            color("Christmas",
+                  bg_color=0xFF2222, fg_color=0x00DD00, chart_color=0x00DD00,
+                  fingering_color=0xFFFF80, drill_note_color=0xCCCCCC),
+            color("Default",
+                  bg_color=0x0000FF, fg_color=0xFFFFFF, chart_color=0xFFFFFF,
+                  fingering_color=0xFF0000, drill_note_color=0x00FF00),
+            color("Solarized Dark",
+                  bg_color=0x002B36, fg_color=0x93A1A1, chart_color=0x93A1A1,
+                  fingering_color=0xB58900, drill_note_color=0x2AA198),
+            color("Dracula",
+                  bg_color=0x282A36, fg_color=0xF8F8F2, chart_color=0xF8F8F2,
+                  fingering_color=0xFF79C6, drill_note_color=0x50FA7B),
+            color("Gruvbox Dark",
+                  bg_color=0x282828, fg_color=0xEBDBB2, chart_color=0xEBDBB2,
+                  fingering_color=0xFE8019, drill_note_color=0xB8BB26),
+            color("Monokai",
+                  bg_color=0x272822, fg_color=0xF8F8F2, chart_color=0xF8F8F2,
+                  fingering_color=0xF92672, drill_note_color=0xA6E22E),
+        ]),
+        {"text": "Volume", "type": "volume_settings"},
+        {"text": "Drill", "type": "drill_settings"},
+    ]),
+])

--- a/hardware/metronome.py
+++ b/hardware/metronome.py
@@ -1,0 +1,109 @@
+import array
+import asyncio
+import math
+import time
+
+import audiocore
+
+
+class Metronome:
+    """A self-driving beat-clock device.
+
+    Construct once with a hardware reference. `start(bpm)` launches an internal
+    asyncio task that wakes on each beat boundary and fires a click via the
+    mixer. Callers only **read** from the metronome — `pulse_intensity(now)`
+    for a decaying 0..1 value to drive a visual, `beat_count` for the
+    total beats fired since start, `last_beat_at` for the wall-clock time
+    of the most recent beat. Nothing the caller does advances the clock.
+
+    The click sample is generated in-memory at construction (no asset file).
+    It's a short damped sine — sounds like a soft tick — matched to the
+    SaxHardware mixer's 22050 Hz / 16-bit signed mono format.
+    """
+
+    CLICK_VOICE = 1            # accompaniment voice; song mode also uses this
+    CLICK_FREQ_HZ = 2000.0
+    CLICK_DURATION_S = 0.03
+    CLICK_DECAY_RATE = 120.0   # exponential decay constant; bigger = snappier
+
+    def __init__(self, hardware, on_beat=None):
+        """`on_beat`, if given, is called as `on_beat(beat_time)` immediately
+        after each click fires. Use it to drive any beat-synchronous side
+        effects (visual pulse, drill advancement, etc.) — anything that needs
+        to happen on the beat goes through this hook rather than polling."""
+        self.hw = hardware
+        self.bpm = 0
+        self.beat_interval = 0.0
+        self.last_beat_at = None    # monotonic() of the most recent fired beat
+        self.beat_count = 0         # total beats fired since the current start()
+        self.on_beat = on_beat
+        self._task = None
+        self._click_sample = self._make_click_sample()
+
+    def _make_click_sample(self):
+        sample_rate = 22050
+        n = int(sample_rate * self.CLICK_DURATION_S)
+        samples = array.array("h")
+        amplitude = 0x6FFF  # leave headroom against clipping
+        for i in range(n):
+            t = i / sample_rate
+            envelope = math.exp(-t * self.CLICK_DECAY_RATE)
+            value = int(amplitude * envelope * math.sin(2.0 * math.pi * self.CLICK_FREQ_HZ * t))
+            samples.append(value)
+        try:
+            return audiocore.RawSample(samples, sample_rate=sample_rate)
+        except Exception as e:
+            print(f"Metronome: could not build click sample ({e}); will run silent.")
+            return None
+
+    def start(self, bpm):
+        """Begin ticking at the given BPM. Launches the internal task; cancels
+        any previous task first."""
+        if bpm <= 0:
+            return
+        self.stop()
+        self.bpm = bpm
+        self.beat_interval = 60.0 / bpm
+        self.beat_count = 0
+        self.last_beat_at = None
+        self._task = asyncio.create_task(self._run())
+
+    def stop(self):
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        self.bpm = 0
+        self.beat_interval = 0.0
+        try:
+            self.hw.mixer.voice[self.CLICK_VOICE].stop()
+        except Exception:
+            pass
+
+    async def _run(self):
+        """Internal beat loop. Fires a beat, sleeps to the next boundary,
+        repeats. Schedule (not delays) is what's tracked, so individual sleeps
+        being slightly long don't cause cumulative drift."""
+        next_beat = time.monotonic()
+        try:
+            while True:
+                delay = next_beat - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                self._fire_beat(next_beat)
+                next_beat += self.beat_interval
+        except asyncio.CancelledError:
+            pass
+
+    def _fire_beat(self, beat_time):
+        self.last_beat_at = beat_time
+        self.beat_count += 1
+        if self._click_sample is not None:
+            try:
+                self.hw.mixer.voice[self.CLICK_VOICE].play(self._click_sample, loop=False)
+            except Exception as e:
+                print(f"Metronome click failed: {e}")
+        if self.on_beat is not None:
+            try:
+                self.on_beat(beat_time)
+            except Exception as e:
+                print(f"Metronome on_beat handler failed: {e}")

--- a/states/drill_settings_state.py
+++ b/states/drill_settings_state.py
@@ -1,0 +1,69 @@
+import asyncio
+
+from hardware.buttons import Buttons
+from states.state_utils import SelectableList
+
+
+class DrillSettingsState:
+    """Settings screen for persisted drill defaults (BPM, mode). Mirrors
+    VolumeSettingsState — title reflects the live values, items are pure
+    actions. Changes also write through to ScaleDrillState.SESSION_MODE so
+    the toggle takes effect this session, not just next boot."""
+
+    def __init__(self, hw, config):
+        self.hw = hw
+        self.config = config
+        self._dirty = False
+
+        self.items = [
+            {"text": "< Back",       "action": "back"},
+            {"text": "Toggle Mode",  "action": "toggle_mode"},
+            {"text": "BPM Up",       "action": "bpm_up"},
+            {"text": "BPM Down",     "action": "bpm_down"},
+        ]
+
+        self.selectable_list = SelectableList(title=self._title(), config=config)
+        self.hw.display.root_group = self.selectable_list.ui_group
+        self.selectable_list.set_items(self.items, title=self._title())
+
+    def _title(self):
+        drill = self.config.drill_data
+        return f"BPM {drill.default_bpm}  {drill.default_mode.upper()}"
+
+    def _apply_session_mode(self):
+        # Import here to avoid a circular import at module-load time.
+        from states.scale_drill_state import ScaleDrillState
+        ScaleDrillState.SESSION_MODE = self.config.drill_data.default_mode
+
+    def _refresh_title(self):
+        self.selectable_list.title_label.text = self._title()
+
+    async def run(self):
+        while True:
+            self.hw.update_button_states()
+
+            if Buttons.R_1.just_pressed:
+                self.selectable_list.move_up()
+            elif Buttons.R_2.just_pressed:
+                self.selectable_list.move_down()
+            elif Buttons.L_SELECT.just_pressed:
+                action = self.selectable_list.get_selected_item().get("action")
+                if action == "toggle_mode":
+                    self.config.drill_data.toggle_mode()
+                    self._apply_session_mode()
+                    self._dirty = True
+                    self._refresh_title()
+                elif action == "bpm_up":
+                    self.config.drill_data.step_bpm_up()
+                    self._dirty = True
+                    self._refresh_title()
+                elif action == "bpm_down":
+                    self.config.drill_data.step_bpm_down()
+                    self._dirty = True
+                    self._refresh_title()
+                elif action == "back":
+                    if self._dirty:
+                        self.config.persist()
+                    return
+
+            await asyncio.sleep(0.01)

--- a/states/menu_state.py
+++ b/states/menu_state.py
@@ -78,6 +78,9 @@ class MenuState:
                 elif item_type == "volume_settings":
                     from states.volume_settings_state import VolumeSettingsState
                     await self._transition_to_state(VolumeSettingsState)
+                elif item_type == "drill_settings":
+                    from states.drill_settings_state import DrillSettingsState
+                    await self._transition_to_state(DrillSettingsState)
                 elif item_type == "song":
                     payload = selected_item.get("payload", {})
                     from states.song_state import SongState

--- a/states/scale_drill_state.py
+++ b/states/scale_drill_state.py
@@ -10,8 +10,9 @@ from adafruit_display_text import label
 from composer.key_signature import KeySignatures
 from composer.notes import Duration, Notes as ComposerNotes, Rest, TimedNote
 from composer.staff import Staff
-from data.config import Config
+from data.config import Config, DrillConfig
 from hardware.buttons import Buttons
+from hardware.metronome import Metronome
 from states.play_state import PlayState
 
 
@@ -50,9 +51,18 @@ def parse_drill_item(name):
 
 
 class ScaleDrillState(PlayState):
-    DEFAULT_BPM = 72
-    HOLD_FACTOR = 0.9  # fraction of the musical duration the player must hold to advance
-    MIN_HOLD = 0.2    # floor so fast tempos / eighths don't become twitchy
+    MIN_HOLD = 0.2    # easy-mode floor so fast tempos / eighths don't become twitchy
+    LEAD_IN_BEATS = 4  # number of quarter rests prepended in timed mode (1 measure of 4/4)
+    PULSE_FLASH_S = 0.15  # how long the mode label stays in the pulse color after a beat
+
+    # Re-export DrillConfig's canonical mode constants so callers within this
+    # module don't have to import data.config just to compare a mode value.
+    MODE_TIMED = DrillConfig.MODE_TIMED
+    MODE_EASY = DrillConfig.MODE_EASY
+    # Class-level — persists in-memory across drills within a session, gets
+    # re-seeded from config.drill_data.default_mode on boot (see code.py).
+    # The ready-phase R_1 toggle and the Drill settings screen both write here.
+    SESSION_MODE = MODE_TIMED
 
     # Musical beat counts (eighth=0.5, unlike Staff.DURATION_BEATS which is column-width).
     _HOLD_BEATS = {
@@ -70,7 +80,9 @@ class ScaleDrillState(PlayState):
         super().__init__(hardware, config, title=self.drill_name, key_signature=key_signature, enable_progress=True)
 
         self.config = config
-        self.bpm = payload.get("bpm", self.DEFAULT_BPM)
+        # Payload BPM wins (per-drill override); otherwise fall back to the
+        # user's persisted drill default. DrillConfig owns the default value.
+        self.bpm = payload.get("bpm", config.drill_data.default_bpm)
         # Scoring attributes
         self.total_score = 0
         self.note_start_time = None
@@ -91,6 +103,57 @@ class ScaleDrillState(PlayState):
         self.score_label.anchor_point = (0.5, 0.0)
         self.score_label.anchored_position = (160, 5)
         self.ui_group.append(self.score_label)
+
+        # Mode label sits directly under the drill name (title is at y=15 in
+        # PlayState). Doubles as the metronome pulse indicator in timed mode —
+        # color flashes on each beat.
+        self.mode_label = label.Label(
+            terminalio.FONT,
+            text=self._mode_label_text(),
+            color=config.color_data.fg_color,
+            scale=1,
+        )
+        self.mode_label.anchor_point = (0.0, 0.0)
+        self.mode_label.anchored_position = (10, 28)
+        self.ui_group.append(self.mode_label)
+
+        # Ready-phase prompts (two lines below the staff). Removed once the
+        # drill starts. fingering_color makes them visually distinct from the
+        # default fg_color used by every other on-screen element.
+        self.ready_prompt_select = label.Label(
+            terminalio.FONT,
+            text="SELECT: start",
+            color=config.color_data.fingering_color,
+            scale=1,
+        )
+        self.ready_prompt_select.anchor_point = (0.5, 0.5)
+        self.ready_prompt_select.anchored_position = (160, 210)
+        self.ui_group.append(self.ready_prompt_select)
+
+        self.ready_prompt_toggle = label.Label(
+            terminalio.FONT,
+            text="R1: toggle mode",
+            color=config.color_data.fingering_color,
+            scale=1,
+        )
+        self.ready_prompt_toggle.anchor_point = (0.5, 0.5)
+        self.ready_prompt_toggle.anchored_position = (160, 226)
+        self.ui_group.append(self.ready_prompt_toggle)
+
+        # Metronome — constructed lazily when timed mode actually starts.
+        self.metronome = None
+
+        # Timed-mode bookkeeping. current_item_start_time is the wall-clock
+        # anchor for the current drill item; the next item's anchor is just
+        # this + musical_duration, which keeps the grid drift-free relative
+        # to the metronome. _timed_satisfied_seconds is the cumulative time
+        # the user has satisfied the current item — scoring is proportional
+        # to satisfied_seconds / musical_duration. _timed_satisfied_since is
+        # the start of the current in-progress satisfaction streak (None
+        # when not currently satisfying).
+        self.current_item_start_time = None
+        self._timed_satisfied_seconds = 0.0
+        self._timed_satisfied_since = None
 
         item_names = payload.get("notes", [])
         self.notes = [parse_drill_item(name) for name in item_names]
@@ -119,9 +182,17 @@ class ScaleDrillState(PlayState):
             self.drill_staff.static_group.pop()
         self.ui_group.insert(1, self.drill_staff)
 
+    def musical_duration_for(self, item):
+        """Seconds the item occupies musically — the fill grows to 100% over
+        this duration, matching the metronome's beat timeline."""
+        return (60.0 / self.bpm) * self._HOLD_BEATS[item.duration]
+
     def required_hold_for(self, item):
-        """Seconds the player must hold (or rest) to advance past this item."""
-        seconds = (60.0 / self.bpm) * self._HOLD_BEATS[item.duration] * self.HOLD_FACTOR
+        """Seconds the player must hold (or rest) to advance past this item.
+        Slightly less than the musical duration (hold_factor) so they can drop
+        off the last sliver of the note without penalty. MIN_HOLD is a floor
+        for very fast tempos / eighths so it doesn't get twitchy."""
+        seconds = self.musical_duration_for(item) * self.config.drill_data.hold_factor
         return max(seconds, self.MIN_HOLD)
 
     def _item_satisfied(self, item, target_note, breathing):
@@ -130,7 +201,84 @@ class ScaleDrillState(PlayState):
             return not breathing
         return target_note == item.note and breathing
 
+    def _mode_label_text(self):
+        return "[TIMED]" if ScaleDrillState.SESSION_MODE == self.MODE_TIMED else "[EASY]"
+
+    def _on_beat(self, beat_time):
+        """Single entry point for everything that happens on a metronome beat.
+        Called from Metronome's internal task — synchronous, runs after the
+        click fires.
+
+        Today: spawn the visual pulse flash. Coming next: drive drill_index
+        advancement and per-note scoring in strict-timing mode. Adding those
+        is a new branch here, not a new polling loop somewhere else."""
+        asyncio.create_task(self._flash_pulse())
+
+    async def _flash_pulse(self):
+        """Briefly recolor the mode label so the user sees the beat. Run as a
+        task so it doesn't block the metronome's beat loop."""
+        self.mode_label.color = self.config.color_data.drill_note_color
+        await asyncio.sleep(self.PULSE_FLASH_S)
+        self.mode_label.color = self.config.color_data.fg_color
+
+    async def _ready_phase(self):
+        """Pre-drill: clean screen with just title, mode indicator, and prompts.
+        Waits for SELECT to start or R_1 to toggle mode. The staff, drill notes,
+        and fingering chart all stay hidden until the drill actually begins."""
+        if self.hw.display.root_group != self.ui_group:
+            self.hw.display.root_group = self.ui_group
+
+        # Hide the staves so the ready screen doesn't show notes or a clef.
+        self.staff.hidden = True
+        self.drill_staff.hidden = True
+        # chart_sprite isn't in ui_group yet — it gets added after ready phase.
+
+        self.hw.display.refresh()
+
+        while self.is_running:
+            self.hw.update_button_states()
+
+            if Buttons.L_SELECT.just_pressed:
+                break
+            if Buttons.R_1.just_pressed:
+                ScaleDrillState.SESSION_MODE = (
+                    self.MODE_EASY if ScaleDrillState.SESSION_MODE == self.MODE_TIMED
+                    else self.MODE_TIMED
+                )
+                self.mode_label.text = self._mode_label_text()
+                self.hw.display.refresh()
+
+            await asyncio.sleep(0.01)
+
+        # Restore visibility and tear down the ready-only prompts.
+        self.staff.hidden = False
+        self.drill_staff.hidden = False
+        if self.ready_prompt_select in self.ui_group:
+            self.ui_group.remove(self.ready_prompt_select)
+        if self.ready_prompt_toggle in self.ui_group:
+            self.ui_group.remove(self.ready_prompt_toggle)
+        self.hw.display.refresh()
+
     async def run(self):
+        await self._ready_phase()
+        if not self.is_running:
+            return
+
+        # Timed-mode setup: prepend lead-in rests so the user has a count-in,
+        # then start the metronome. Recompute the score multiplier because
+        # len(self.notes) just grew.
+        if ScaleDrillState.SESSION_MODE == self.MODE_TIMED:
+            lead_in = [Rest(Duration.QUARTER) for _ in range(self.LEAD_IN_BEATS)]
+            self.notes = lead_in + self.notes
+            self.SCORE_MULTIPLY_CONSTANT = (
+                self.MAX_POSSIBLE_SCORE / (len(self.notes) * self.MAX_POSSIBLE_PER_NOTE) * 1.004
+            )
+            self.metronome = Metronome(self.hw, on_beat=self._on_beat)
+            # Anchor the first item to the same monotonic instant the metronome
+            # starts at — beat boundaries and item boundaries then share a grid.
+            self.current_item_start_time = time.monotonic()
+            self.metronome.start(self.bpm)
+
         drill_index = 0
         last_drawn_index = -1
         self.note_start_time = time.monotonic()
@@ -149,7 +297,15 @@ class ScaleDrillState(PlayState):
                 break
 
             current_item = self.notes[drill_index]
-            required_hold = self.required_hold_for(current_item)
+            musical_duration = self.musical_duration_for(current_item)
+            # Timed mode skips MIN_HOLD: the beat ticks regardless of the user,
+            # so there's no twitchy-advance concern at fast tempos. Without
+            # this, MIN_HOLD could push required_hold above musical_duration
+            # for short items and the fill would never reach 100%.
+            if ScaleDrillState.SESSION_MODE == self.MODE_TIMED:
+                required_hold = musical_duration * self.config.drill_data.hold_factor
+            else:
+                required_hold = self.required_hold_for(current_item)
 
             if drill_index != last_drawn_index:
                 self.draw_drill_note(drill_index, 3)
@@ -163,25 +319,78 @@ class ScaleDrillState(PlayState):
             breathing = self.hw.breath_sensor.breath_sensor_triggered
             current_time = time.monotonic()
 
-            # 1. DETECTION: Are they satisfying the current item right now?
-            if self._item_satisfied(current_item, target_note, breathing):
-                if self.note_played_time is None:
-                    self.note_played_time = current_time
-            else:
-                # Wrong note / breath mismatch breaks the hold
-                if self.note_played_time is not None:
+            satisfied_now = self._item_satisfied(current_item, target_note, breathing)
+
+            if ScaleDrillState.SESSION_MODE == self.MODE_TIMED:
+                # Timed mode: fill is anchored to the beat grid. Advance fires
+                # on the full musical_duration regardless of whether they
+                # played, but fill reaches 100% at required_hold (hold_factor
+                # of the beat) so the last sliver is free breathing room.
+                elapsed_in_item = current_time - self.current_item_start_time
+                self.staff.set_progress(elapsed_in_item / required_hold)
+
+                # Track cumulative satisfied time as opening/closing streaks.
+                if satisfied_now:
+                    if self._timed_satisfied_since is None:
+                        self._timed_satisfied_since = current_time
+                else:
+                    if self._timed_satisfied_since is not None:
+                        self._timed_satisfied_seconds += current_time - self._timed_satisfied_since
+                        self._timed_satisfied_since = None
+
+                if elapsed_in_item >= musical_duration:
+                    # Close any in-progress streak at the item boundary so it
+                    # doesn't leak into the next item. If they're still
+                    # holding, the streak picks up from the boundary instant
+                    # against the next item's window.
+                    item_end = self.current_item_start_time + musical_duration
+                    if self._timed_satisfied_since is not None:
+                        self._timed_satisfied_seconds += item_end - self._timed_satisfied_since
+                        self._timed_satisfied_since = item_end
+                    # Score caps at required_hold, not musical_duration — playing
+                    # the required_hold window earns a full slice; the remaining
+                    # ~20% of the beat is breathing room and doesn't penalize.
+                    satisfied_fraction = min(1.0, self._timed_satisfied_seconds / required_hold)
+                    slice_max = int(self.MAX_POSSIBLE_SCORE / len(self.notes))
+                    slice_score = int(slice_max * satisfied_fraction)
+                    if slice_score > 0:
+                        self.total_score += slice_score
+                        self.score_label.text = str(self.total_score)
+
+                    if self.hint_task is not None:
+                        self.hint_task.cancel()
+                        self.hint_task = None
+                    if self.current_hint_fingering is not None:
+                        await self.clear_specific_fingering(self.current_hint_fingering)
+                        self.current_hint_fingering = None
+
+                    # Keep the next item's anchor on the same grid as the
+                    # metronome by adding musical_duration — using monotonic()
+                    # here would let drift creep in.
+                    drill_index += 1
+                    self.current_item_start_time += musical_duration
+                    self._timed_satisfied_seconds = 0.0
+                    self.note_start_time = time.monotonic()
                     self.note_played_time = None
-
-            # 2. VALIDATION: Have they held it long enough to earn the score?
-            #    Also drive the visual hold-progress fill on the play staff overlay.
-            if self.note_played_time is not None:
-                self.staff.set_progress((current_time - self.note_played_time) / required_hold)
+                    # Skip animate_score_text in timed mode — it blocks the
+                    # timeline. Score updates in-place via score_label.
             else:
-                self.staff.set_progress(0.0)
+                # Easy mode: event-driven advance based on hold satisfaction.
+                if satisfied_now:
+                    if self.note_played_time is None:
+                        self.note_played_time = current_time
+                else:
+                    if self.note_played_time is not None:
+                        self.note_played_time = None
 
-            if self.note_played_time is not None:
-                if current_time - self.note_played_time >= required_hold:
-                    # SUCCESS! Now we calculate and award the score
+                # Fill reaches 100% at required_hold so the visual cue and the
+                # advance threshold match — when the note looks done, it is done.
+                if self.note_played_time is not None:
+                    self.staff.set_progress((current_time - self.note_played_time) / required_hold)
+                else:
+                    self.staff.set_progress(0.0)
+
+                if self.note_played_time is not None and current_time - self.note_played_time >= required_hold:
                     if self.note_start_time is None:
                         self.note_start_time = self.note_played_time
 
@@ -194,19 +403,15 @@ class ScaleDrillState(PlayState):
 
                     print(f"Success! Score awarded: {score}")
 
-                    # Cancel hint cycle if it's running
                     if self.hint_task is not None:
                         self.hint_task.cancel()
                         self.hint_task = None
-
                     if self.current_hint_fingering is not None:
                         await self.clear_specific_fingering(self.current_hint_fingering)
                         self.current_hint_fingering = None
 
-                    # Animate score flash, then advance — sequential keeps display updates isolated
                     await self.animate_score_text()
 
-                    # Move to next item and reset state
                     drill_index += 1
                     self.note_start_time = time.monotonic()
                     self.note_played_time = None
@@ -219,8 +424,15 @@ class ScaleDrillState(PlayState):
                 if time.monotonic() - self.note_start_time > self.MAX_POSSIBLE_PER_NOTE - 2:
                     self.hint_task = asyncio.create_task(self.cycle_fingerings(current_item.note))
 
+            # No beat-related polling here — beat-driven side effects (visual
+            # pulse, and eventually drill advancement) all flow through the
+            # metronome's on_beat hook, dispatched by self._on_beat.
+
             # yield control for other code to run
             await asyncio.sleep(0.001)
+
+        if self.metronome is not None:
+            self.metronome.stop()
 
         # Cancel any leftover hint tasks upon exiting
         if self.hint_task is not None:
@@ -373,4 +585,15 @@ class ScaleDrillState(PlayState):
 
     def draw_drill_note(self, first_index, count):
         items_to_show = self.notes[first_index:min(first_index + count, len(self.notes))]
+        # Accumulate the layout-beat position of the first visible item so the
+        # staff can draw measure lines at the right places as the window scrolls.
+        # Uses Staff.DURATION_BEATS (the column-width measure) for consistency
+        # with how the layout itself positions items.
+        start_beat = 0
+        for i in range(first_index):
+            start_beat += Staff.DURATION_BEATS.get(self.notes[i].duration, 1)
         self.drill_staff.update_sequence(items_to_show)
+        # Measure lines render on the base staff (not drill_staff) so they
+        # share the staff-line color source. drill_staff's fg_color is
+        # overridden to drill_note_color; the base staff is unmodified.
+        self.staff.set_measure_lines(items_to_show, start_beat=start_beat)


### PR DESCRIPTION
Adds a metronome that will play beats according to provided BPM.
Adds measure lines
Adds a timed and easy mode to drills. 
 - Timed mode will advance notes regardless of whether you play them, and score according to the time you played the right note.
 - Easy mode works as before, will only advance when you play the right note
Adds configurable BPM and timed vs easy mode.
Fixes rest drawing, was off by one
